### PR TITLE
PR#3 phase 3 - component: event-to-pipeline-name resolver

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/EventToPipelineNameResolver.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/EventToPipelineNameResolver.java
@@ -1,0 +1,21 @@
+package co.elastic.logstash.filters.elasticintegration;
+
+import co.elastic.logstash.api.Event;
+import co.elastic.logstash.filters.elasticintegration.resolver.UncacheableResolver;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * An {@code EventToPipelineNameResolver} is capable of determining the name of a
+ * single target pipeline for an {@link Event}.
+ *
+ * <p>
+ *     Implementations <em>MUST NOT</em> cache the events themselves,
+ *     but <em>MAY</em> perform internal caching of low-cardinality things from the events.
+ * </p>
+ */
+public interface EventToPipelineNameResolver extends UncacheableResolver<Event, String> {
+    @Override
+    Optional<String> resolve(Event event, Consumer<Exception> exceptionHandler);
+}

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/FieldValueEventToPipelineNameResolver.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/FieldValueEventToPipelineNameResolver.java
@@ -1,0 +1,22 @@
+package co.elastic.logstash.filters.elasticintegration;
+
+import co.elastic.logstash.api.Event;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static co.elastic.logstash.filters.elasticintegration.util.EventUtil.ensureValidFieldReference;
+import static co.elastic.logstash.filters.elasticintegration.util.EventUtil.safeExtractString;
+
+public class FieldValueEventToPipelineNameResolver implements EventToPipelineNameResolver {
+    private final String fieldReference;
+
+    public FieldValueEventToPipelineNameResolver(String fieldReference) {
+        this.fieldReference = ensureValidFieldReference(fieldReference, "pipeline name");
+    }
+
+    @Override
+    public Optional<String> resolve(Event event, Consumer<Exception> exceptionHandler) {
+        return Optional.ofNullable(safeExtractString(event, fieldReference));
+    }
+}

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/util/EventUtil.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/util/EventUtil.java
@@ -1,0 +1,32 @@
+package co.elastic.logstash.filters.elasticintegration.util;
+
+import co.elastic.logstash.api.Event;
+import org.logstash.FieldReference;
+
+import java.util.Objects;
+
+public class EventUtil {
+    private EventUtil() {
+    }
+
+    public static String safeExtractString(final Event event, final String fieldReference) {
+        return safeExtractValue(event, fieldReference, String.class);
+    }
+
+    static <T> T safeExtractValue(final Event event, final String fieldReference, final Class<T> tClass) {
+        final Object fieldValue = event.getField(fieldReference);
+
+        if (Objects.nonNull(fieldValue) && tClass.isAssignableFrom(fieldValue.getClass())) {
+            return tClass.cast(fieldValue);
+        }
+
+        return null;
+    }
+
+    public static String ensureValidFieldReference(final String fieldReference, final String descriptor) {
+        if (!FieldReference.isValid(fieldReference)) {
+            throw new IllegalArgumentException(String.format("Invalid field reference for `%s`: `%s`", descriptor, fieldReference));
+        }
+        return fieldReference;
+    }
+}

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/FieldValueEventToPipelineNameResolverTest.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/FieldValueEventToPipelineNameResolverTest.java
@@ -1,0 +1,47 @@
+package co.elastic.logstash.filters.elasticintegration;
+
+import co.elastic.logstash.api.Event;
+import org.junit.jupiter.api.Test;
+import org.logstash.plugins.BasicEventFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static co.elastic.logstash.filters.elasticintegration.util.EventTestUtil.eventFromMap;
+import static co.elastic.logstash.filters.elasticintegration.util.EventTestUtil.mapWithNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class FieldValueEventToPipelineNameResolverTest {
+
+    static final EventToPipelineNameResolver fieldExtractor = new FieldValueEventToPipelineNameResolver("[deeply][nested][field]");
+    @Test
+    void testEventIncludesFieldWithStringValue() {
+        final Event event = eventFromMap(Map.of("deeply", Map.of("nested", Map.of("field", "my-pipeline-name"))));
+        assertThat(fieldExtractor.resolve(event), is(equalTo(Optional.of("my-pipeline-name"))));
+    }
+
+    @Test
+    void testEventIncludesFieldWithNullValue() {
+        final Event event = eventFromMap(Map.of("deeply", Map.of("nested", mapWithNullValue("field"))));
+        assertThat(fieldExtractor.resolve(event), is(equalTo(Optional.empty())));
+    }
+
+    @Test
+    void testEventIncludesFieldWithNonStringValue() {
+        final Event event = eventFromMap(Map.of("deeply", Map.of("nested", Map.of("field", 1337L))));
+        assertThat(fieldExtractor.resolve(event), is(equalTo(Optional.empty())));
+
+        final Event event2 = eventFromMap(Map.of("deeply", Map.of("nested", Map.of("field", Map.of("deeper","value")))));
+        assertThat(fieldExtractor.resolve(event2), is(equalTo(Optional.empty())));
+    }
+
+    @Test
+    void testEventExcludesField() {
+        final Event event = eventFromMap(Map.of());
+        assertThat(fieldExtractor.resolve(event), is(equalTo(Optional.empty())));
+    }
+}

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/util/EventTestUtil.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/util/EventTestUtil.java
@@ -1,0 +1,21 @@
+package co.elastic.logstash.filters.elasticintegration.util;
+
+import co.elastic.logstash.api.Event;
+import org.logstash.plugins.BasicEventFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EventTestUtil {
+
+    public static Event eventFromMap(final Map<String, Object> map) {
+        return BasicEventFactory.INSTANCE.newEvent(map);
+    }
+
+    public static Map<String,Object> mapWithNullValue(final String key) {
+        final Map<String, Object> intermediate = new HashMap<>();
+        intermediate.put(key, null);
+        return Collections.unmodifiableMap(intermediate);
+    }
+}

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/util/EventUtilTest.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/util/EventUtilTest.java
@@ -1,0 +1,76 @@
+package co.elastic.logstash.filters.elasticintegration.util;
+
+import co.elastic.logstash.api.Event;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static co.elastic.logstash.filters.elasticintegration.util.EventTestUtil.eventFromMap;
+import static co.elastic.logstash.filters.elasticintegration.util.EventUtil.safeExtractValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class EventUtilTest {
+    @Test
+    void testEnsureValidFieldReferenceBareword() {
+        EventUtil.ensureValidFieldReference("abc", "bareword");
+    }
+    @Test
+    void testEnsureValidFieldReferencePathspec() {
+        EventUtil.ensureValidFieldReference("[a][b][c]", "path spec");
+    }
+    @Test
+    void testEnsureValidFieldReferenceNestedPathspec() {
+        EventUtil.ensureValidFieldReference("[a][[b][c]]", "nestedpath spec");
+    }
+    @Test
+    void testEnsureValidFieldReferenceBroken() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            EventUtil.ensureValidFieldReference("ab[c", "corrupt");
+        });
+    }
+    @Test
+    void testEnsureValidFieldReferenceTrailingBrackets() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            EventUtil.ensureValidFieldReference("a[]", "trailing brackets");
+        });
+    }
+    @Test
+    void testEnsureValidFieldReferenceTrailingIndexBrackets() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            EventUtil.ensureValidFieldReference("abc[0]", "trailing index brackets");
+        });
+    }
+
+    @Test
+    void testSafeExtractValue() {
+        final Event event = eventFromMap(Map.of(
+                "nest", Map.of(
+                        "list-str", List.of("a","b","c"),
+                        "list-lon", List.of(1,2,3),
+                        "lon", 17,
+                        "str", "ok-string")));
+
+        assertAll("success cases", () -> {
+            assertThat(safeExtractValue(event, "[nest][str]", String.class), is(equalTo("ok-string")));
+            assertThat(safeExtractValue(event, "[nest][list-str][1]", String.class), is(equalTo("b")));
+
+            assertThat(safeExtractValue(event, "[nest][lon]", Long.class), is(equalTo(17L)));
+            assertThat(safeExtractValue(event, "[nest][list-lon][1]", Long.class), is(equalTo(2L)));
+        });
+
+        assertAll("missing value", () -> {
+            assertThat(safeExtractValue(event, "[missing][str]", String.class), is(nullValue()));
+            assertThat(safeExtractValue(event, "[missing][list-str][1]", String.class), is(nullValue()));
+        });
+
+        assertAll("casting issue", () -> {
+            assertThat(safeExtractValue(event, "[nest]", String.class), is(nullValue()));
+            assertThat(safeExtractValue(event, "[missing][list-str][1]", Long.class), is(nullValue()));
+        });
+    }
+
+}


### PR DESCRIPTION
Introduces a Resolver<Event,String> interface for extracting pipeline names from events, along with a simple implementation that safely extracts a pre-determined field value