### PR TITLE
add lucene-analysis, a dependency of the HtmlStripProcessor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,7 +209,7 @@ task importMinimalElasticsearch(dependsOn: buildElasticsearchLocalDistro) {
                 include jarPackageNamed("elasticsearch-core")
                 include jarPackageNamed("elasticsearch-x-content")
                 include jarPackageNamed("lucene-core")
-                include jarPackageNamed("lucene-analysis")
+                include jarPackageNamed("lucene-analysis-common")
             }
 
             from("${elasticsearchBuildTree}/modules/ingest-common") {


### PR DESCRIPTION
Resolves an issue where loading a pipeline that includes the `html_strip_processor` fails with:

> ```
> Failure/Error: Unable to find  org.elasticsearch.ingest.common.HtmlStripProcessor.process(org/elasticsearch/ingest/common/HtmlStripProcessor.java to read failed line, Java::JavaLang::NoClassDefFoundError: org/apache/lucene/analysis/charfilter/HTMLStripCharFilter          
> ```