### PR TITLE
boundary: prevent reserved-field conflicts between Event and IngestDocument

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -76,6 +76,7 @@ You can configure this plugin to present authentication credentials to Elasticse
 NOTE: Request authentication is not a substitute for SSL, as it provides neither secrecy nor security on its own.
 When used with SSL disabled, these auth credentials are transmitted in effectively clear-text and can be easily recovered by an adversary.
 
+[id="plugins-{type}s-{plugin}-supported_ingest_processors"]
 ==== Supported Ingest Processors
 
 This filter can run Elasticsearch Ingest Node pipelines that are _wholly_ comprised of the supported subset of processors, with access to the Painless and Mustache scripting engines where applicable:
@@ -123,6 +124,29 @@ This filter can run Elasticsearch Ingest Node pipelines that are _wholly_ compri
 h| GeoIp
 | `geoip` | Requires local MaxMind GeoIp databases <<plugins-{type}s-{plugin}-geoip_database_directory>>
 
+|=======================================================================
+
+
+[id="plugins-{type}s-{plugin}-field_mappings"]
+===== Field Mappings
+
+During execution, the Ingest pipeline works with a temporary mutable _view_ of the Logstash event that re-shapes some {ls}-reserved fields into their expected IngestDocument field names and object-types.
+Changes to the IngestDocument will be reflected in the resulting Logstash Event, including safely mapping these reserved fields _back_ from the IngestDocument reserved field to the {ls} reserved field counterpart.
+
+[cols="<,<,<",options="header"]
+|=======================================================================
+
+| {ls} Field | IngestDocument Field | Conflict Handling
+
+| `@timestamp` | `_ingest.timestamp` |when ingest processing _also_ sets a top-level `@timestamp` field, it will be made available via the Event's `_@timestamp` field
+
+| `@version` | `_version` | when ingest processing _also_ sets a top-level `@version` field in the source, it will be made available via the Event's `_@version` field
+
+| `@metadata` | `@metadata` | when ingest processing replaces the top-level `@metadata` map with an object that is not a string-object map, it will be made available via the Event's `_@metadata` field.
+
+| `tags` | `tags` | when ingest processing produces a top-level `tags` field that is not a collection of strings, it will be made available via the event's `_tags` field.
+
+| _everything else_ | _in-place, as-structured_ | only minimal type conversions are done
 |=======================================================================
 
 [id="plugins-{type}s-{plugin}-options"]

--- a/spec/integration/elastic_integration_spec.rb
+++ b/spec/integration/elastic_integration_spec.rb
@@ -303,7 +303,7 @@ describe 'Logstash executes ingest pipeline', :secure_integration => true do
           expect(event.get("clientip")).to eql "1.2.3.4"
           expect(event.get("ident")).to eql "-"
           expect(event.get("auth")).to eql "-"
-          expect(event.get("@timestamp")).to eql "01/Apr/2023:22:00:52 +0000"
+          expect(event.get("_@timestamp")).to eql "01/Apr/2023:22:00:52 +0000" # reserved-field collision re-routing
           expect(event.get("verb")).to eql "GET"
           expect(event.get("request")).to eql "/path/to/some/resources/test.gif"
           expect(event.get("httpversion")).to eql "1.0"

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestDuplexMarshaller.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestDuplexMarshaller.java
@@ -4,21 +4,38 @@ import co.elastic.logstash.api.Event;
 import co.elastic.logstash.api.EventFactory;
 import org.elasticsearch.ingest.IngestDocument;
 import org.logstash.Javafier;
-import org.logstash.Valuefier;
 import org.logstash.plugins.BasicEventFactory;
 
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAccessor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * The {@code IngestDuplexMarshaller} is capable of marshalling events between the internal logstash {@link Event}
  * and the external Elasticsearch {@link IngestDocument}.
  */
 public class IngestDuplexMarshaller {
-    private static final String INGEST_TIMESTAMP = "timestamp";
+    static final String INGEST_METADATA_TIMESTAMP_FIELD = "timestamp";
     private final EventFactory eventFactory;
 
+    static final String LOGSTASH_VERSION_FALLBACK = "_@version";
+    static final String LOGSTASH_TIMESTAMP_FALLBACK = "_@timestamp";
+    static final String LOGSTASH_METADATA_FALLBACK = "_@metadata";
+    static final String LOGSTASH_TAGS_FALLBACK = "_tags";
+
     private static final IngestDuplexMarshaller DEFAULT_INSTANCE = new IngestDuplexMarshaller(BasicEventFactory.INSTANCE);
+
+    private static final ZoneId UTC = ZoneId.of("UTC");
 
     private IngestDuplexMarshaller(final EventFactory eventFactory) {
         this.eventFactory = eventFactory;
@@ -29,65 +46,142 @@ public class IngestDuplexMarshaller {
     }
 
     public IngestDocument toIngestDocument(final Event event) {
-        Map<String, Object> data = new HashMap<>();
-        Map<String, Object> ingestMetadata = new HashMap<>();
+        Map<String, Object> sourceAndMetadata = new HashMap<>();
 
-        // handle timestamp separately
-        // TODO hack to work around Logstash's API package only exposing a millisecond timestamp
-        ingestMetadata.put(INGEST_TIMESTAMP, ((org.logstash.Event) event).getTimestamp());
-
-        // ensure events have a _version
-        data.put(IngestDocument.Metadata.VERSION.getFieldName(), 1L);
-
-        for (Map.Entry<String, Object> entry : event.getData().entrySet()) {
-            if (!entry.getKey().equals(org.logstash.Event.TIMESTAMP)) {
-                data.put(entry.getKey(), Javafier.deep(entry.getValue()));
+        // The public Elasticsearch IngestDocument constructor accepts a single source-and-metadata map,
+        // which it splits into two maps based keys being valid IngestDocument.Metadata properties.
+        // we copy the entirety of the event's top-level fields into this _except_ the @timestamp and @version
+        // which have special handling below
+        event.getData().forEach((eventKey, eventValue) -> {
+            if (eventKey.equals(org.logstash.Event.TIMESTAMP) || eventKey.equals(org.logstash.Event.VERSION)) {
+                // no-op; handled outside of iteration
+            } else {
+                sourceAndMetadata.put(eventKey, Javafier.deep(eventValue));
             }
+        });
+        // Map Event metadata onto `@metadata` within source
+        final Map<String, Object> eventMetadata = event.getMetadata();
+        if (!eventMetadata.isEmpty()) {
+            sourceAndMetadata.put(org.logstash.Event.METADATA, Javafier.deep(eventMetadata));
         }
 
-        final Map<String,Object> metadata = new HashMap<>();
-        for (Map.Entry<String, Object> entry : event.getMetadata().entrySet()) {
-            metadata.put(entry.getKey(), Javafier.deep(entry.getValue()));
-        }
-        data.put("@metadata", metadata);
+        // IngestDocument's metadata REQUIRES a _version, so we extract it from the event's @version if available
+        // or provide a sensible default
+        sourceAndMetadata.putIfAbsent(IngestDocument.Metadata.VERSION.getFieldName(), ingestDocumentVersion(event));
 
-        return new IngestDocument(data, ingestMetadata);
+        // When an IngestDocument is initialized, its "ingestMetadata" is only expected to contain the
+        // event's timestamp, which is copied into the event
+        Map<String, Object> ingestMetadata = Map.of(INGEST_METADATA_TIMESTAMP_FIELD, ingestDocumentTimestamp(event));
+
+        return new IngestDocument(sourceAndMetadata, ingestMetadata);
     }
 
-    public Event toLogstashEvent(final IngestDocument document) {
-        Map<String, Object> source = document.getSourceAndMetadata();
-        Map<String, Object> metadata = document.getIngestMetadata();
+    private long ingestDocumentVersion(final Event event) {
+        final Object eventVersionValue = event.getField(org.logstash.Event.VERSION);
+        if (Objects.nonNull(eventVersionValue)) {
+            final Object jVersionField = Javafier.deep(eventVersionValue);
+            if (jVersionField instanceof String) { // most common
+                try {
+                    return Long.parseLong((String) jVersionField);
+                } catch (NumberFormatException nfe) {
+                    // noop
+                }
+            }
+            if (jVersionField instanceof Long) {
+                return (Long) jVersionField;
+            }
+            if (jVersionField instanceof Integer) {
+                return (Integer) jVersionField;
+            }
+        }
+        return 1L; // usable default
+    }
 
-        final Event e = eventFactory.newEvent();
+    /**
+     * Extract an {@link IngestDocument}-compatible timestamp from an {@link Event}.
+     * Avoids {@link Event#getEventTimestamp()} because it loses millis.
+     *
+     * @param event the event from which to extract a {@code @timestamp}
+     * @return a {@link ZonedDateTime} that is the same moment-in-time as the event's timestamp
+     */
+    private ZonedDateTime ingestDocumentTimestamp(final Event event) {
+        final Object eventTimestampValue = event.getField(org.logstash.Event.TIMESTAMP);
+        if (Objects.nonNull(eventTimestampValue)) {
+            if (eventTimestampValue instanceof org.logstash.Timestamp) {
+                return ZonedDateTime.ofInstant(((org.logstash.Timestamp) eventTimestampValue).toInstant(), UTC);
+            }
+        }
+        return ZonedDateTime.now(UTC); // usable default
+    }
 
-        // handle timestamp separately
-        Object z = metadata.get(INGEST_TIMESTAMP);
-        if (z != null) {
-            // TODO hack to work around Logstash's API package only exposing a millisecond timestamp
-            ((org.logstash.Event) e).setTimestamp((org.logstash.Timestamp) z);
+    public Event toLogstashEvent(final IngestDocument ingestDocument) {
+        // the IngestDocument we get back will have modified source directly,
+        // and may have modified metadata.
+        Map<String, Object> eventMap = new HashMap<>(ingestDocument.getSourceAndMetadata());
+
+        // extract and set the version, moving a pre-existing `@version` field out of the way
+        final Object sourceVersion = eventMap.put(org.logstash.Event.VERSION, eventVersion(ingestDocument));
+        if (Objects.nonNull(sourceVersion)) {
+            eventMap.put(LOGSTASH_VERSION_FALLBACK, sourceVersion);
         }
 
-        // handle version separately
-        Long version = (Long) source.get(IngestDocument.Metadata.VERSION.getFieldName());
-        if (version != null) {
-            e.getData().put(org.logstash.Event.VERSION, String.valueOf(version));
+        // extract and set the timestamp, moving a pre-existing `@timestamp` field out of the way
+        final Object sourceTimestamp = eventMap.put(org.logstash.Event.TIMESTAMP, eventTimestamp(ingestDocument));
+        if (Objects.nonNull(sourceTimestamp)) {
+            System.out.format("TS(%s): %s\n", sourceTimestamp.getClass(), sourceTimestamp);
+            eventMap.put(LOGSTASH_TIMESTAMP_FALLBACK, sourceTimestamp);
         }
 
-        for (Map.Entry<String, Object> entry : source.entrySet()) {
-            String key = entry.getKey();
+        // if the source included `@metadata` that was not a map, move it to fallback
+        final Object sourceMetadata = eventMap.get(org.logstash.Event.METADATA);
+        if (Objects.isNull(sourceMetadata)) {
+            eventMap.remove(org.logstash.Event.METADATA, null);
+        } else if (!(sourceMetadata instanceof Map)) {
+            eventMap.remove(org.logstash.Event.METADATA, sourceMetadata);
+            eventMap.put(LOGSTASH_METADATA_FALLBACK, sourceMetadata);
+        }
 
-            if ((!key.equals(org.logstash.Event.VERSION)) &&
-                    (!key.equals(IngestDocument.Metadata.VERSION.getFieldName()))) {
-                e.setField(entry.getKey(), Valuefier.convert(entry.getValue()));
+        // if the source included top-level `tags`, replace it with a coercible
+        // representation or pre-emptively move it to fallback
+        final Object sourceTags = eventMap.remove(org.logstash.Event.TAGS);
+        if (Objects.nonNull(sourceTags)) {
+            final Object coercibleTags = likelyCoercibleTags(sourceTags);
+            if (Objects.nonNull(coercibleTags)) {
+                eventMap.put(org.logstash.Event.TAGS, coercibleTags);
+            } else {
+                eventMap.put(LOGSTASH_TAGS_FALLBACK, sourceTags);
             }
         }
 
-        for (Map.Entry<String, Object> entry : metadata.entrySet()) {
-            if (!entry.getKey().equals(INGEST_TIMESTAMP)) {
-                e.setField(entry.getKey(), Valuefier.convert(entry.getValue()));
-            }
-        }
+        return eventFactory.newEvent(eventMap);
+    }
 
-        return e;
+    private static org.logstash.Timestamp eventTimestamp(final IngestDocument ingestDocument) {
+        final Object o = ingestDocument.getIngestMetadata().get(INGEST_METADATA_TIMESTAMP_FIELD);
+        try {
+            if (Objects.nonNull(o) && o instanceof TemporalAccessor) {
+                final Instant instant = Instant.from((TemporalAccessor) o);
+                return new org.logstash.Timestamp(instant);
+            }
+        } catch (DateTimeException e) {
+            // noop
+        }
+        return new org.logstash.Timestamp();
+    }
+
+    private static String eventVersion(final IngestDocument ingestDocument) {
+        return Long.toString(ingestDocument.getMetadata().getVersion());
+    }
+
+    private static Object likelyCoercibleTags(final Object rawTagsValue) {
+        // Logstash core handles Java types String and List<?>
+        if (rawTagsValue instanceof List) { return rawTagsValue; }
+        if (rawTagsValue instanceof String) { return rawTagsValue; }
+
+        // Extend to support Set
+        if (rawTagsValue instanceof Set) { return new ArrayList<>((Set<?>) rawTagsValue); }
+
+        return null;
     }
 }
+

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/EventMatchers.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/EventMatchers.java
@@ -7,6 +7,7 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.hamcrest.TypeSafeMatcher;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.anything;
@@ -34,7 +35,7 @@ class EventMatchers {
         @Override
         protected boolean matchesSafely(Event event) {
             return Optional.ofNullable(event.getField("tags"))
-                    .filter(Collection.class::isInstance).map(Collection.class::cast)
+                    .map(IsEventTagged::normalizeTagsValue)
                     .filter(tagsCollection -> tagsCollection.contains(expectedTag))
                     .isPresent();
         }
@@ -51,6 +52,11 @@ class EventMatchers {
             } else {
                 mismatchDescription.appendText("had tags").appendValue(event.getField("tags"));
             }
+        }
+
+        private static Collection<?> normalizeTagsValue(final Object rawTags) {
+            if (rawTags instanceof Collection) { return (Collection<?>) rawTags; }
+            return Collections.singleton(rawTags);
         }
     }
 
@@ -73,7 +79,7 @@ class EventMatchers {
 
         @Override
         public void describeTo(Description description) {
-            description.appendText(String.format("have not field `%s`", this.fieldReference));
+            description.appendText(String.format("not have field `%s`", this.fieldReference));
         }
     }
 

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/IngestDuplexMarshallerTest.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/IngestDuplexMarshallerTest.java
@@ -1,0 +1,246 @@
+package co.elastic.logstash.filters.elasticintegration;
+
+import co.elastic.logstash.api.Event;
+import org.elasticsearch.ingest.IngestDocument;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.jupiter.api.Test;
+import org.logstash.plugins.BasicEventFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.Temporal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static co.elastic.logstash.filters.elasticintegration.EventMatchers.*;
+import static co.elastic.logstash.filters.elasticintegration.IngestDuplexMarshaller.*;
+import static co.elastic.logstash.filters.elasticintegration.TemporalMatchers.recentCurrentTimestamp;
+import static com.github.seregamorph.hamcrest.MoreMatchers.where;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class IngestDuplexMarshallerTest {
+
+    private static final IngestDuplexMarshaller IDM = IngestDuplexMarshaller.defaultInstance();
+
+    @Test
+    void basicRoundTrip() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("@timestamp", "2023-01-17T23:19:04.765182352Z", "@version", "3", "message", "hello, world", "@metadata", Map.of("this", "that","flip", "flop")));
+
+        final Event output = IDM.toLogstashEvent(IDM.toIngestDocument(input));
+
+        assertThat(output, includesField(org.logstash.Event.TIMESTAMP).withValue(equalTo(input.getField(org.logstash.Event.TIMESTAMP))));
+        assertThat(output, includesField(org.logstash.Event.VERSION).withValue(equalTo(input.getField(org.logstash.Event.VERSION))));
+
+        assertThat(output, includesField("message").withValue(equalTo(input.getField("message"))));
+        assertThat(output, includesField("[@metadata][this]").withValue(equalTo("that")));
+        assertThat(output, includesField("[@metadata][flip]").withValue(equalTo("flop")));
+    }
+
+    @Test
+    void ingestDocToEventModifiedTimestamp() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("@timestamp", "2023-01-17T23:19:04.765182352Z", "@version", "3", "message", "hello, world"));
+        final IngestDocument intermediate = IDM.toIngestDocument(input);
+
+        final ZonedDateTime updatedTimestamp = ZonedDateTime.parse("2023-03-12T01:17:38.135792468Z");
+        intermediate.setFieldValue(IngestDocument.INGEST_KEY + "." + INGEST_METADATA_TIMESTAMP_FIELD, updatedTimestamp);
+
+        final Event output = IDM.toLogstashEvent(intermediate);
+
+        assertThat(output, includesField(org.logstash.Event.TIMESTAMP).withValue(where(org.logstash.Timestamp::toInstant, is(equalTo(updatedTimestamp.toInstant())))));
+        assertThat(output, includesField(org.logstash.Event.VERSION).withValue(equalTo(input.getField(org.logstash.Event.VERSION))));
+    }
+
+    @Test
+    void ingestDocToEventRemovedTimestamp() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("@timestamp", "2023-01-17T23:19:04.765182352Z", "@version", "3", "message", "hello, world"));
+        final IngestDocument intermediate = IDM.toIngestDocument(input);
+
+        intermediate.removeField(IngestDocument.INGEST_KEY + "." + INGEST_METADATA_TIMESTAMP_FIELD);
+
+        final Event output = IDM.toLogstashEvent(intermediate);
+
+        assertThat(output, includesField(org.logstash.Event.TIMESTAMP).withValue(where(org.logstash.Timestamp::toInstant, is(recentCurrentTimestamp()))));
+        assertThat(output, includesField(org.logstash.Event.VERSION).withValue(equalTo(input.getField(org.logstash.Event.VERSION))));
+    }
+
+    @Test
+    void ingestDocToEventIncludingReservedAtTimestampField() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("@timestamp", "2023-01-17T23:19:04.765182352Z", "@version", "3", "message", "hello, world"));
+        final IngestDocument intermediate = IDM.toIngestDocument(input);
+
+        // intentionally String to pass-through Valuifier#convert and make validation easier
+        final String atTimestampInSource = "2023-03-12T01:17:38.135792468Z";
+        intermediate.setFieldValue(org.logstash.Event.TIMESTAMP, atTimestampInSource);
+
+        final Event output = IDM.toLogstashEvent(intermediate);
+
+        assertThat(output, includesField(org.logstash.Event.TIMESTAMP).withValue(equalTo(input.getField(org.logstash.Event.TIMESTAMP))));
+        assertThat(output, includesField(org.logstash.Event.VERSION).withValue(equalTo(input.getField(org.logstash.Event.VERSION))));
+
+        assertThat(output, includesField(LOGSTASH_TIMESTAMP_FALLBACK).withValue(equalTo(atTimestampInSource)));
+    }
+
+    @Test
+    void ingestDocToEventIncludingReservedAtVersionField() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("@timestamp", "2023-01-17T23:19:04.765182352Z", "@version", "3", "message", "hello, world"));
+        final IngestDocument intermediate = IDM.toIngestDocument(input);
+
+        final String atVersionInSource = "bananas";
+        intermediate.setFieldValue(org.logstash.Event.VERSION, atVersionInSource);
+
+        final Event output = IDM.toLogstashEvent(intermediate);
+
+        assertThat(output, includesField(org.logstash.Event.TIMESTAMP).withValue(equalTo(input.getField(org.logstash.Event.TIMESTAMP))));
+        assertThat(output, includesField(org.logstash.Event.VERSION).withValue(equalTo(input.getField(org.logstash.Event.VERSION))));
+
+        assertThat(output, includesField(LOGSTASH_VERSION_FALLBACK).withValue(equalTo(atVersionInSource)));
+    }
+
+    @Test
+    void ingestDocToEventIncludingReservedAtMetadataFieldWithAcceptableShape() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("@timestamp", "2023-01-17T23:19:04.765182352Z", "@version", "3", "message", "hello, world"));
+        final IngestDocument intermediate = IDM.toIngestDocument(input);
+
+        final Map<String,Object> atMetadataInSource = Map.of("this", "that","flip", "flop");
+        intermediate.setFieldValue(org.logstash.Event.METADATA, atMetadataInSource);
+
+        final Event output = IDM.toLogstashEvent(intermediate);
+
+        assertThat(output, includesField(org.logstash.Event.TIMESTAMP).withValue(equalTo(input.getField(org.logstash.Event.TIMESTAMP))));
+        assertThat(output, includesField(org.logstash.Event.VERSION).withValue(equalTo(input.getField(org.logstash.Event.VERSION))));
+
+        assertThat(output, includesField("[@metadata][this]").withValue(equalTo("that")));
+        assertThat(output, includesField("[@metadata][flip]").withValue(equalTo("flop")));
+    }
+
+    @Test
+    void ingestDocToEventIncludingReservedAtMetadataFieldWithInvalidShape() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("@timestamp", "2023-01-17T23:19:04.765182352Z", "@version", "3", "message", "hello, world"));
+        final IngestDocument intermediate = IDM.toIngestDocument(input);
+
+        final List<String> atMetadataInSource = List.of("wrong", "incorrect");
+        intermediate.setFieldValue(org.logstash.Event.METADATA, atMetadataInSource);
+
+        final Event output = IDM.toLogstashEvent(intermediate);
+
+        assertThat(output, includesField(org.logstash.Event.TIMESTAMP).withValue(equalTo(input.getField(org.logstash.Event.TIMESTAMP))));
+        assertThat(output, includesField(org.logstash.Event.VERSION).withValue(equalTo(input.getField(org.logstash.Event.VERSION))));
+        assertThat(output.getMetadata(), is(anEmptyMap()));
+
+        assertThat(output, includesField(LOGSTASH_METADATA_FALLBACK).withValue(equalTo(atMetadataInSource)));
+    }
+
+    @Test
+    void ingestDocToEventIncludingReservedTagsFieldWithInvalidShape() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("message", "hello, world"));
+        final IngestDocument intermediate = IDM.toIngestDocument(input);
+
+        final Map<String,Object> atTagsInSource = Map.of("this", "that");
+        intermediate.setFieldValue(org.logstash.Event.TAGS, atTagsInSource);
+
+        final Event output = IDM.toLogstashEvent(intermediate);
+
+        assertThat(output, excludesField(org.logstash.Event.TAGS));
+        assertThat(output, includesField("[" + LOGSTASH_TAGS_FALLBACK + "][this]").withValue(equalTo("that")));
+    }
+
+    @Test
+    void ingestDocToEventIncludingReservedTagsFieldWithInvalidCoercibleShape() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("message", "hello, world"));
+        final IngestDocument intermediate = IDM.toIngestDocument(input);
+
+        final Set<String> atTagsInSource = Set.of("this", "that");
+        intermediate.setFieldValue(org.logstash.Event.TAGS, atTagsInSource);
+
+        final Event output = IDM.toLogstashEvent(intermediate);
+
+        assertThat(output, isTagged("this"));
+        assertThat(output, isTagged("that"));
+        assertThat(output, excludesField(LOGSTASH_TAGS_FALLBACK));
+    }
+
+    @Test
+    void ingestDocToEventIncludingReservedTagsFieldWithStringShape() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("message", "hello, world"));
+        final IngestDocument intermediate = IDM.toIngestDocument(input);
+
+        final String atTagsInSource = "this";
+        intermediate.setFieldValue(org.logstash.Event.TAGS, atTagsInSource);
+
+        final Event output = IDM.toLogstashEvent(intermediate);
+
+        assertThat(output, isTagged("this"));
+        assertThat(output, excludesField(LOGSTASH_TAGS_FALLBACK));
+    }
+
+    @Test
+    void ingestDocToEventIncludingReservedTagsFieldWithListOfStringShape() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("message", "hello, world"));
+        final IngestDocument intermediate = IDM.toIngestDocument(input);
+
+        final List<String> atTagsInSource = List.of("this", "that");
+        intermediate.setFieldValue(org.logstash.Event.TAGS, atTagsInSource);
+
+        final Event output = IDM.toLogstashEvent(intermediate);
+
+        assertThat(output, isTagged("this"));
+        assertThat(output, isTagged("that"));
+        assertThat(output, excludesField(LOGSTASH_TAGS_FALLBACK));
+
+        // guarantee _should_ belong to LS core
+        assertAll("providing immutable list doesn't prevent future tagging", ()->{
+            output.tag("another");
+            assertThat("new tag is applied", output, isTagged("another"));
+            assertThat("previous tags are still present", output, both(isTagged("this")).and(isTagged("that")));
+        });
+    }
+
+    @Test
+    void eventToIngestDoc() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("@timestamp", "2023-01-17T23:19:04.765182352Z", "@version", "3", "message", "hello, world", "@metadata", Map.of("this", "that","flip", "flop")));
+
+        final IngestDocument ingestDocument = IDM.toIngestDocument(input);
+
+        final ZonedDateTime ingestTimestamp = getIngestDocumentTimestamp(ingestDocument);
+        assertThat(ingestTimestamp, is(notNullValue()));
+        assertThat(ingestTimestamp.toInstant(), is(equalTo(getEventTimestamp(input))));
+
+        assertThat(ingestDocument.getMetadata().getVersion(), is(equalTo(3L)));
+    }
+
+    @Test
+    void eventToIngestDocMissingRequiredVersion() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("@timestamp", "2023-01-17T23:19:04.765182352Z", "@version", "3", "message", "hello, world", "@metadata", Map.of("this", "that","flip", "flop")));
+        input.remove(org.logstash.Event.VERSION);
+
+        final IngestDocument ingestDocument = IDM.toIngestDocument(input);
+
+        // sensible default
+        assertThat(ingestDocument.getMetadata().getVersion(), is(equalTo(1L)));
+    }
+
+    @Test
+    void eventToIngestDocMissingRequiredTimestamp() {
+        final Event input = BasicEventFactory.INSTANCE.newEvent(Map.of("@timestamp", "2023-01-17T23:19:04.765182352Z", "@version", "3", "message", "hello, world", "@metadata", Map.of("this", "that","flip", "flop")));
+        input.remove(org.logstash.Event.TIMESTAMP);
+
+        final IngestDocument ingestDocument = IDM.toIngestDocument(input);
+
+        final ZonedDateTime ingestTimestamp = getIngestDocumentTimestamp(ingestDocument);
+        assertThat(ingestTimestamp, is(recentCurrentTimestamp()));
+    }
+
+    Instant getEventTimestamp(final Event event) {
+        return ((org.logstash.Timestamp) event.getField(org.logstash.Event.TIMESTAMP)).toInstant();
+    }
+
+    ZonedDateTime getIngestDocumentTimestamp(final IngestDocument ingestDocument) {
+        return ingestDocument.getFieldValue(IngestDocument.INGEST_KEY + "." + INGEST_METADATA_TIMESTAMP_FIELD, ZonedDateTime.class);
+    }
+}

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/TemporalMatchers.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/TemporalMatchers.java
@@ -1,0 +1,41 @@
+package co.elastic.logstash.filters.elasticintegration;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.Temporal;
+
+public class TemporalMatchers {
+
+    static <T extends Temporal> Matcher<T> recentCurrentTimestamp() {
+        return recentCurrentTimestamp(Duration.ofMillis(100));
+    }
+
+    static <T extends Temporal> Matcher<T> recentCurrentTimestamp(final Duration maxAge) {
+        return new TypeSafeDiagnosingMatcher<>() {
+
+            @Override
+            protected boolean matchesSafely(final T timestamp, final Description mismatchDescription) {
+                final Instant now = Instant.now();
+                final Duration actualDelta = Duration.between(Instant.from(timestamp), now);
+                if (actualDelta.isNegative()) {
+                    mismatchDescription.appendText("value was in the future");
+                    return false;
+                }
+                if (maxAge.minus(actualDelta).isNegative()) {
+                    mismatchDescription.appendText("value was too old").appendText("(").appendValue(actualDelta).appendText(")");
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("be less than ").appendValue(maxAge).appendText("in the past");
+            }
+        };
+    }
+}


### PR DESCRIPTION
Specifies how fields are mapped from a Logstash Event to an IngestDocument, including conflict handling of reserved fields.

IngestDocument required-and-reserved fields are sourced from the Event's comparable present-by-default reserved fields where possible, falling through to sensible defaults, and are used as the source-of-truth when reconstituting the Event, routing also-in-source Logstash reserved fields to appropriate fallback locations.

Logstash reserved Event fields that do _not_ have a reserved counterpart in IngestDocument are appropriately validated and coerced or possibly re-reouted in order to avoid exceptions or creating "poison" events.