### PR TITLE
This fixes no jar found by adding `*.gemspec` file to dependency list.

### DIFF
--- a/logstash-filter-elastic_integration.gemspec
+++ b/logstash-filter-elastic_integration.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   # Files
   s.files = Dir[*%w{
     lib/**/*.*
+    *.gemspec
     vendor/jar-dependencies/**/*.jar
     VERSION
     LICENSE


### PR DESCRIPTION
### Issue description

When installing the plugin with Logstash distribution, we get following error:

```
[2023-04-05T10:24:22,995][ERROR][logstash.agent           ] Failed to execute action 
{:action=>LogStash::PipelineAction::Create/pipeline_id:main, :exception=>"Java::JavaLang::IllegalStateException",
 :message=>"Unable to configure plugins: (RuntimeError) \n\n\tyou might need to reinstall the gem which depends on the 
missing jar or in case there is Jars.lock then resolve the jars with `lock_jars` command\n\nno such file to load -- 
co/elastic/logstash/plugins/filter/elasticintegration/logstash-filter-elastic_integration/0.0.1/logstash-filter-elastic_integration-
0.0.1.jar (LoadError)", :backtrace=>["org.logstash.config.ir.CompiledPipeline.<init>(CompiledPipeline.java:120)", 
"org.logstash.execution.AbstractPipelineExt.initialize(AbstractPipelineExt.java:186)", 
"org.logstash.execution.AbstractPipelineExt$INVOKER$i$initialize.call(AbstractPipelineExt$INVOKER$i$initialize.gen)", 
"org.jruby.internal.runtime.methods.JavaMethod$JavaMethodN.call(JavaMethod.java:846)", 
...
"org.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:107)", "java.base/java.lang.Thread.run(Thread.java:833)"]}
```


### PR changes
This PR adds the `logstash-filter-elastic_integration.gemspec` to the plugin dependency files so that dependant `jar` file be resolved.