### PR TITLE
meta: add readme with minimal subset found in other plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Elastic Integration plugin for Logstash
+
+This is a plugin for [Logstash](https://github.com/elastic/logstash), and is not meant to be used on its own.
+
+It can be used in a Logstash pipeline to perform the transformations that are applied by many [Elastic Integrations](https://www.elastic.co/integrations/data-integrations) _before_ sending the events to Elasticsearch.
+
+## Documentation
+
+Logstash provides infrastructure to automatically generate documentation for this plugin from its [asciidoc source](docs/index.asciidoc).
+All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).


### PR DESCRIPTION
 - I intentionally omitted information about Licensing, as `main` is currently "All Rights Reserved" until #30 lands.
 - I intentionally omitted how-to-use and how-to-develop sections, as the instructions in other plugins do not apply directly and I do not have time to develop a complete new guide.