### PR TITLE
gemspec: add source code metadata

### DIFF
--- a/logstash-filter-elastic_integration.gemspec
+++ b/logstash-filter-elastic_integration.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.metadata = {
     "logstash_plugin" => "true",
     "logstash_group" => "filter",
+    "source_code_uri" => "https://github.com/elastic/logstash-filter-elastic_integration",
   }
 
   # Gem dependencies


### PR DESCRIPTION
In order to include plugins from outside the `logstash-plugins` github org in our docs build, the gem must include a metadata key `source_code_uri` whose value is [the URL to a github repository][1].

[1]: https://github.com/elastic/docs-tools/blob/e62a5d2b6f50d160e272d3e269e1c9536eb23988/plugindocs.rb#L156