### PR TITLE
caches: adjust to 1-hr hit cache and 1-minute miss cache

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
@@ -53,9 +53,9 @@ public class EventProcessorBuilder {
         final EventProcessorBuilder builder = new EventProcessorBuilder();
 
         builder.setEventPipelineNameResolver(new DatastreamEventToPipelineNameResolver(elasticsearchRestClient, new SimpleResolverCache<>("datastream-to-pipeline",
-                new SimpleResolverCache.Configuration(Duration.ofSeconds(60), Duration.ofSeconds(10)))));
+                new SimpleResolverCache.Configuration(Duration.ofMinutes(60), Duration.ofSeconds(60)))));
         builder.setPipelineConfigurationResolver(new ElasticsearchPipelineConfigurationResolver(elasticsearchRestClient));
-        builder.setPipelineResolverCacheConfig(Duration.ofSeconds(60), Duration.ofSeconds(10));
+        builder.setPipelineResolverCacheConfig(Duration.ofMinutes(60), Duration.ofSeconds(60));
         return builder;
     }
 


### PR DESCRIPTION
We plan to make the cache effectively-permanent in the future with a companion cache invalidator to keep our cached values in sync, so that we don't block processing to reload things that likely haven't changed.

This isn't that effort.

But in the mean-time, we can adjust our hit-cache to 1 hour, and our miss-cache to 60s, so that processing will receive pauses significantly less frequently.