### PR TITLE
WIP: event processor: support an Executor

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/util/ExecutorServiceCloser.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/util/ExecutorServiceCloser.java
@@ -1,0 +1,43 @@
+package co.elastic.logstash.filters.elasticintegration.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ExecutorServiceCloser implements Closeable {
+    private static final Logger LOGGER = LogManager.getLogger(ExecutorServiceCloser.class);
+
+    private final ExecutorService executorService;
+
+    public ExecutorServiceCloser(final ExecutorService executorService) {
+        this.executorService = executorService;
+    }
+
+    @Override
+    public void close() throws IOException {
+        LOGGER.info("Shutting down ExecutorService...");
+        executorService.shutdown();
+        final int limit = 30;
+        if (!executorService.isTerminated()) {
+            for (int attempt = 1; attempt <= limit; attempt++) {
+                LOGGER.debug(String.format("waiting on previously-submitted work to finish (%s/%s)", attempt, limit));
+                try {
+                    if (executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+                        LOGGER.info("ExecutorService has been shut down.");
+                        return;
+                    }
+                } catch (InterruptedException e) {
+                    LOGGER.warn("ExecutorService was interrupted while attempting to shut down gracefully");
+                    throw new RuntimeException(e);
+                }
+            }
+            LOGGER.warn("ExecutorService failed to shut down gracefully and will be forced to shut down");
+            executorService.shutdownNow();
+        }
+
+    }
+}


### PR DESCRIPTION
A WIP draft to show where we would inject an Executor (or ExecutorService) in order to decouple this filter's processing power from the number of workers allocated to the pipeline.

By default it uses the executor `Runnable#run` to simply run the task in the same thread, but it has room to either use a pre-initialized and unmanaged `ExecutorService` or to manage the lifecycle of an `ExecutorService` including initialization and shutdown-at-close.