### PR TITLE
Add minimum Logstash core requirement to use the plugin.

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,1 +1,0 @@
-# logstash-input-elastic_integration

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -29,7 +29,7 @@ Use of this plugin requires an active Enterprise Elastic License.
 
 Using this filter you can process Elastic integrations powered by {es} Ingest Node in Logstash.
 
-Once configured to point to an {es} cluster, events processed by this filter will first resolve their effective data-stream, and determine from elasticsearch which ingest pipeline to run.
+Once configured to point to an {es} cluster, events processed by this filter will first resolve their effective data-stream, and determine from {es} which ingest pipeline to run.
 The ingest pipeline will be run inside Logstash without transmitting the event to {es}.
 Events that are successfully handled by their ingest pipeline will have `[@metadata][target_ingest_pipeline]` set to `+_none+` so that any downstream {es} output in the Logstash pipeline will avoid running the event's default pipeline _again_ in {es}.
 
@@ -37,6 +37,8 @@ NOTE: Some multi-pipeline configurations such as logstash-to-logstash over http(
       In these setups, you may need to explicitly configure your downstream pipeline's {es} output with `+pipeline => "_none"+` to avoid re-running the default pipeline.
 
 Events that _fail_ ingest pipeline processing will be tagged with `_ingest_pipeline_failure`, and their `[@metadata][_ingest_pipeline_failure]` will be populated with details as a key/value map.
+
+IMPORTANT: This plugin requires minimum Java 17 and Logstash 8.7.0 versions.
 
 .Technology Preview
 ****

--- a/logstash-filter-elastic_integration.gemspec
+++ b/logstash-filter-elastic_integration.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency "logstash-core", ">= 8.7.0"
 
   s.add_development_dependency 'logstash-devutils'
 


### PR DESCRIPTION
### PR description
This PR is the separation of [this, Java and LS-core version requirements PR](https://github.com/elastic/logstash-filter-elastic_integration/pull/43/files) and since we cannot run the plugin with < Java 17 versions, we aim only to include LS-core.

- Adds the minimum requirement of Logstash core v8.7.0 to use the plugin.
- Adds a note about minimum Java and Logstash version requirements in the doc.