### PR TITLE
Decrease a noise with pipeline is not found message.

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/ElasticsearchPipelineConfigurationResolver.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/ElasticsearchPipelineConfigurationResolver.java
@@ -47,7 +47,7 @@ public class ElasticsearchPipelineConfigurationResolver
             return Optional.of(pipelineConfiguration);
         } catch (ResponseException re) {
             if (re.getResponse().getStatusLine().getStatusCode() == 404) {
-                LOGGER.warn(String.format("pipeline not found: `%s`", pipelineName), re.getMessage());
+                LOGGER.debug(String.format("pipeline not found: `%s`", pipelineName), re);
             } else {
                 LOGGER.error(String.format("failed to fetch pipeline: `%s`", pipelineName), re);
                 throw re;


### PR DESCRIPTION
### Description
Avoid logging unnecessary stack trace messages with pipeline not found `WARN` message.
Details: https://github.com/elastic/logstash-filter-elastic_integration/issues/59#issuecomment-1538501993

```
[2023-04-28T21:40:55,192][WARN ][co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolver][main][868fb41462280b855612169a4cd2c7fdaf7bafbcc950221299209ae8f899f0bd] pipeline not found: `logs-elastic_agent.filebeat@custom`
org.elasticsearch.client.ResponseException: method [GET], host [https://integration-cf17b8.es.us-central1.gcp.cloud.es.io:443], URI [/_ingest/pipeline/logs-elastic_agent.filebeat@custom], status line [HTTP/1.1 404 Not Found]
{}
        at org.elasticsearch.client.RestClient.convertResponse(RestClient.java:347) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:313) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:288) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolver.resolveSafely(ElasticsearchPipelineConfigurationResolver.java:44) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolver.resolveSafely(ElasticsearchPipelineConfigurationResolver.java:26) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.resolver.AbstractSimpleResolver.resolve(AbstractSimpleResolver.java:32) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolver.resolve(ElasticsearchPipelineConfigurationResolver.java:26) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.SimpleIngestPipelineResolver.resolve(SimpleIngestPipelineResolver.java:58) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.resolver.SimpleResolverCache.doGet(SimpleResolverCache.java:139) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.resolver.SimpleResolverCache.lambda$resolve$4(SimpleResolverCache.java:96) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.resolver.SimpleResolverCache$SimpleMultiLock.lambda$withLock$0(SimpleResolverCache.java:169) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1916) ~[?:?]
        at co.elastic.logstash.filters.elasticintegration.resolver.SimpleResolverCache$SimpleMultiLock.withLock(SimpleResolverCache.java:169) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.resolver.SimpleResolverCache.lambda$resolve$5(SimpleResolverCache.java:94) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1955) ~[?:?]
        at co.elastic.logstash.filters.elasticintegration.resolver.SimpleResolverCache.resolve(SimpleResolverCache.java:89) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.resolver.SimpleCachingResolver.resolve(SimpleCachingResolver.java:37) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.IngestPipelineResolver.resolve(IngestPipelineResolver.java:18) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.resolver.Resolver.resolve(Resolver.java:62) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.ingest.PipelineProcessor.execute(PipelineProcessor.java:65) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.innerExecute(CompoundProcessor.java:193) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at org.elasticsearch.ingest.CompoundProcessor.execute(CompoundProcessor.java:139) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at org.elasticsearch.ingest.Pipeline.execute(Pipeline.java:118) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at org.elasticsearch.ingest.IngestDocument.executePipeline(IngestDocument.java:840) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.IngestPipeline.execute(IngestPipeline.java:42) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.EventProcessor.processEvent(EventProcessor.java:119) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at co.elastic.logstash.filters.elasticintegration.EventProcessor.processEvents(EventProcessor.java:84) ~[logstash-filter-elastic_integration-0.0.1.jar:?]
        at jdk.internal.reflect.GeneratedMethodAccessor54.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
        at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(JavaMethod.java:457) ~[jruby.jar:?]
        at org.jruby.javasupport.JavaMethod.invokeDirect(JavaMethod.java:318) ~[jruby.jar:?]
        at org.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:42) ~[jruby.jar:?]
        at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:173) ~[jruby.jar:?]
        at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:316) ~[jruby.jar:?]
        at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72) ~[jruby.jar:?]
        at org.jruby.ir.interpreter.InterpreterEngine.interpret(InterpreterEngine.java:86) ~[jruby.jar:?]
        at org.jruby.internal.runtime.methods.MixedModeIRMethod.INTERPRET_METHOD(MixedModeIRMethod.java:201) ~[jruby.jar:?]
        at org.jruby.internal.runtime.methods.MixedModeIRMethod.call(MixedModeIRMethod.java:188) ~[jruby.jar:?]
        at org.jruby.internal.runtime.methods.DynamicMethod.call(DynamicMethod.java:218) ~[jruby.jar:?]
        at org.logstash.config.ir.compiler.FilterDelegatorExt.doMultiFilter(FilterDelegatorExt.java:128) ~[logstash-core.jar:?]
        at org.logstash.config.ir.compiler.AbstractFilterDelegatorExt.lambda$multiFilter$0(AbstractFilterDelegatorExt.java:133) ~[logstash-core.jar:?]
        at org.logstash.instrument.metrics.timer.ConcurrentLiveTimerMetric.time(ConcurrentLiveTimerMetric.java:47) ~[logstash-core.jar:?]
        at org.logstash.config.ir.compiler.AbstractFilterDelegatorExt.multiFilter(AbstractFilterDelegatorExt.java:133) ~[logstash-core.jar:?]
        at org.logstash.generated.CompiledDataset2.compute(Unknown Source) ~[?:?]
        at org.logstash.config.ir.CompiledPipeline$CompiledUnorderedExecution.compute(CompiledPipeline.java:347) ~[logstash-core.jar:?]
        at org.logstash.config.ir.CompiledPipeline$CompiledUnorderedExecution.compute(CompiledPipeline.java:341) ~[logstash-core.jar:?]
        at org.logstash.execution.ObservedExecution.lambda$compute$0(ObservedExecution.java:17) ~[logstash-core.jar:?]
        at org.logstash.execution.WorkerObserver.lambda$observeExecutionComputation$0(WorkerObserver.java:39) ~[logstash-core.jar:?]
        at org.logstash.instrument.metrics.timer.ConcurrentLiveTimerMetric.time(ConcurrentLiveTimerMetric.java:47) ~[logstash-core.jar:?]
        at org.logstash.execution.WorkerObserver.lambda$executeWithTimers$1(WorkerObserver.java:50) ~[logstash-core.jar:?]
        at org.logstash.instrument.metrics.timer.ConcurrentLiveTimerMetric.time(ConcurrentLiveTimerMetric.java:47) [logstash-core.jar:?]
        at org.logstash.execution.WorkerObserver.executeWithTimers(WorkerObserver.java:50) [logstash-core.jar:?]
        at org.logstash.execution.WorkerObserver.observeExecutionComputation(WorkerObserver.java:38) [logstash-core.jar:?]
        at org.logstash.execution.ObservedExecution.compute(ObservedExecution.java:17) [logstash-core.jar:?]
        at org.logstash.execution.WorkerLoop.run(WorkerLoop.java:85) [logstash-core.jar:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
        at org.jruby.javasupport.JavaMethod.invokeDirectWithExceptionHandling(JavaMethod.java:442) [jruby.jar:?]
        at org.jruby.javasupport.JavaMethod.invokeDirect(JavaMethod.java:306) [jruby.jar:?]
        at org.jruby.java.invokers.InstanceMethodInvoker.call(InstanceMethodInvoker.java:32) [jruby.jar:?]
        at org.jruby.runtime.callsite.CachingCallSite.cacheAndCall(CachingCallSite.java:351) [jruby.jar:?]
        at org.jruby.runtime.callsite.CachingCallSite.call(CachingCallSite.java:144) [jruby.jar:?]
        at org.jruby.ir.interpreter.InterpreterEngine.processCall(InterpreterEngine.java:345) [jruby.jar:?]
        at org.jruby.ir.interpreter.StartupInterpreterEngine.interpret(StartupInterpreterEngine.java:72) [jruby.jar:?]
        at org.jruby.ir.interpreter.Interpreter.INTERPRET_BLOCK(Interpreter.java:116) [jruby.jar:?]
        at org.jruby.runtime.MixedModeIRBlockBody.commonYieldPath(MixedModeIRBlockBody.java:136) [jruby.jar:?]
        at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:66) [jruby.jar:?]
        at org.jruby.runtime.IRBlockBody.call(IRBlockBody.java:58) [jruby.jar:?]
        at org.jruby.runtime.Block.call(Block.java:143) [jruby.jar:?]
        at org.jruby.RubyProc.call(RubyProc.java:309) [jruby.jar:?]
        at org.jruby.internal.runtime.RubyRunnable.run(RubyRunnable.java:107) [jruby.jar:?]
        at java.lang.Thread.run(Thread.java:833) [?:?]
```

- Closes #59 