### PR TITLE
fix: string-ify logstash timestamp objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
   - Fixes several related issues with how fields are mapped from the Logstash Event to the IngestDocument and back again [#51](https://github.com/elastic/logstash-filter-elastic_integration/pull/51)
     - `IngestDocument` metadata fields are now separately routed to `[@metadata][_ingest_document]` on the resulting `Event`, fixing an issue where the presence of Elasticsearch-reserved fields such as the top-level `_version` would cause a downstream Elasticsearch output to be unable to index the event [#47][]
     - Top-level `@timestamp` and `@version` fields are no longer excluded from the `IngestDocument`, as required by some existing integration pipelines [#54][]
-    - Field-type conversions have been improved by adding a two-way-mapping between the Logstash-internal `Timestamp`-type object and the equivalent `ZonedDateTime`-object used in several Ingest Common processors [#65][]
+    - Field-type conversions have been improved by presenting logstash `Timestamp`-type objects as their ISO8601-encoded `String`s mapping any returned `ZonedDateTime`-objects into logstash `Timestamp`s to support several Ingest Common processors and their typical use in Elastic Integration pipelines [#65][], [#70][]
   - Adds proactive reloaders for both datastream-to-pipeline-name mappings and pipeline definitions to ensure upstream changes are made available without impacting processing [#48](https://github.com/elastic/logstash-filter-elastic_integration/pull/48)
   - Presents helpful guidance when run on an unsupported version of Java [#43](https://github.com/elastic/logstash-filter-elastic_integration/pull/43)
   - Fix: now plugin is able to establish a connection to Elasticsearch on Elastic cloud with `cloud_id` and `cloud_auth` authentication pair [#62](https://github.com/elastic/logstash-filter-elastic_integration/pull/62)
@@ -12,6 +12,7 @@
 [#47]: https://github.com/elastic/logstash-filter-elastic_integration/issues/47
 [#54]: https://github.com/elastic/logstash-filter-elastic_integration/issues/54
 [#65]: https://github.com/elastic/logstash-filter-elastic_integration/issues/65
+[#70]: https://github.com/elastic/logstash-filter-elastic_integration/issues/70
 
 ## 0.0.1
   - Empty Bootstrap of Logstash filter plugin [#1](https://github.com/logstash-plugins/logstash-filter-elastic_integration/pull/1)

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestDuplexMarshaller.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestDuplexMarshaller.java
@@ -100,7 +100,7 @@ public class IngestDuplexMarshaller {
         // When an IngestDocument is initialized, its "ingestMetadata" is only expected to contain the
         // event's timestamp, which is copied into the event and can be either a String or a ZonedDateTime.
         final Timestamp eventTimestamp = safeTimestampFrom(event.getField(org.logstash.Event.TIMESTAMP));
-        Map<String, Object> ingestMetadata = Map.of(INGEST_METADATA_TIMESTAMP_FIELD, Objects.requireNonNullElseGet(eventTimestamp, Timestamp::now).toInstant().atZone(UTC));
+        Map<String, Object> ingestMetadata = Map.of(INGEST_METADATA_TIMESTAMP_FIELD, Objects.requireNonNullElseGet(eventTimestamp, Timestamp::now).toString());
 
         return new IngestDocument(sourceAndMetadata, ingestMetadata);
     }
@@ -132,8 +132,7 @@ public class IngestDuplexMarshaller {
         // then java-ify and perform further conversions
         final Object javafiedInternalObject = Javafier.deep(internalObject);
         if (javafiedInternalObject instanceof Timestamp internalTimestamp) {
-            final ZonedDateTime equivalentZonedDateTime = internalTimestamp.toInstant().atZone(UTC);
-            return equivalentZonedDateTime;
+            return internalTimestamp.toString();
         } else {
             return javafiedInternalObject;
         }


### PR DESCRIPTION
It looks like `ZonedDateTime#toString` is not in fact true ISO8601 and includes a bracketed annotation for the named zone, so it is safer to provide `Timestamp#toString`. This prevents us from doing an auto-magic two-way conversion, but also means that in-the-wild instructions like `"set":{"field":"event.ingested","value":"{{_ingest.timestamp}}"` will properly be ISO8601 as-expected downstream.