### PR TITLE
Add docs to the gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   - Re-syncs with Elasticsearch 8.11 [#91](https://github.com/elastic/logstash-filter-elastic_integration/pull/91)
   - Adds support for Geoip Processor to use databases from Logstash's Geoip Database Management service [#88](https://github.com/elastic/logstash-filter-elastic_integration/pull/88)
   - Restores support for `redact` processor using its x-pack licensed implementation [#90](https://github.com/elastic/logstash-filter-elastic_integration/issues/90)
+  - Include docs in the gem [#95](https://github.com/elastic/logstash-filter-elastic_integration/pull/95)
 
 ## 0.0.3
   - Re-syncs with Elasticsearch 8.10 [#78](https://github.com/elastic/logstash-filter-elastic_integration/pull/78)

--- a/logstash-filter-elastic_integration.gemspec
+++ b/logstash-filter-elastic_integration.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |s|
     vendor/jar-dependencies/**/*.jar
     VERSION
     LICENSE.md
-    NOTICE.txt
+    NOTICE.txt,
+    docs/**/*
   }]
 
   # Special flag to let us know this is actually a logstash plugin


### PR DESCRIPTION
### Description
When we publish docs, we align on versioned docs of the gem. Currently, docs are not included in the gem and [plugin doc is unavailable in the doc-tools](https://github.com/mashhurs/docs-tools/blob/64d8fb0ca14ca04f034ddc73d43915a484149326/plugindocs.rb#L97).
This PR adds a change which docs will be included within the gem.