### PR TITLE
Fix accidental property indent on catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -63,8 +63,8 @@ spec:
         filter_enabled: true
         filter_condition: >-
           build.creator.name == 'elasticmachine' && build.pull_request.id != null
-        cancel_intermediate_builds: true
-        skip_intermediate_builds: true
+      cancel_intermediate_builds: true
+      skip_intermediate_builds: true
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
         ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'


### PR DESCRIPTION
Terrazzo is [blocked on this RRE](https://buildkite.com/elastic/terrazzo/builds/32807#annotation-terrazzo) due to indentation on the properties, this is a pass at attempting to fix that.
https://github.com/elastic/logstash-filter-elastic_integration/blob/c8485e256a5b6f95a738f87d15a0336feb04d033/catalog-info.yaml#L58-L67

This is a super easy mistake to make, the `intermediate_builds` props are part of the overall spec, and not the provider specifications (which confusingly only relate to GitHub hook settings). yaml-language-server was able to catch this using the schema modeline you kindly added, but it helped us identify an issue with rre-cli that will help us provide you with more informative and actionable validation feedback in the future (as opposed to Terrazzo's very vague "something is wrong" error above) 💙 