### PR TITLE
Resolve ES treeish in build pipeline only.

### DIFF
--- a/.buildkite/build-pipeline.yml
+++ b/.buildkite/build-pipeline.yml
@@ -9,8 +9,9 @@ steps:
   # ------------- Build with ES released versions ---------------------
   # 8.x + (SNAPSHOT=FALSE) -> treeish: v8.11.1  artifact: 8.11.1
   - label: ":hammer: Build plugin with released Elasticsearch version :elasticsearch:"
-    command:
-      - .buildkite/scripts/run_tests.sh
+    command: |
+      source .buildkite/scripts/resolve_es_treeish.sh
+      .buildkite/scripts/run_tests.sh
     env:
       ELASTIC_STACK_VERSION: "8.x"
       SNAPSHOT: false
@@ -20,8 +21,9 @@ steps:
   # ------------- Build with ES snapshot versions and main branch ---------------------
   # main + (SNAPSHOT=TRUE) -> treeish: main     artifact:8.12.0-SNAPSHOT
   - label: ":hammer: Build plugin with Elasticsearch snapshot versions and `main` branch :elasticsearch:"
-    command:
-      - .buildkite/scripts/run_tests.sh
+    command: |
+      source .buildkite/scripts/resolve_es_treeish.sh
+      .buildkite/scripts/run_tests.sh
     env:
       ELASTIC_STACK_VERSION: "8.x"
       ELASTICSEARCH_TREEISH: "main"

--- a/.buildkite/scripts/run_tests.sh
+++ b/.buildkite/scripts/run_tests.sh
@@ -1,8 +1,1 @@
-if [ -z "$ELASTICSEARCH_TREEISH" ]; then
-  source .buildkite/scripts/resolve_es_treeish.sh
-  echo "Resolved ELASTICSEARCH_TREEISH: ${ELASTICSEARCH_TREEISH}"
-else
-  echo "Using ELASTICSEARCH_TREEISH ${ELASTICSEARCH_TREEISH} defined in the ENV."
-fi
-
 mkdir -p .ci && curl -sL --retry 5 --retry-delay 5 https://github.com/logstash-plugins/.ci/archive/buildkite-1.x.tar.gz | tar zxvf - --skip-old-files --strip-components=1 -C .ci --wildcards '*Dockerfile*' '*docker*' '*.sh' && .ci/docker-setup.sh && .ci/docker-run.sh


### PR DESCRIPTION
### Description
Real issue: **_difficult to test all pipelines run since we cannot emulate BK pipelines on local._**
We have two separate pipelines for `elastic_integration` plugin and they use common BK scripts. The script to resolve ES treeish is affecting PR BK pipeline which we don't actually need. Proposing to use the ES treeish resolve script only in build pipeline.