### PR TITLE
Fix: when snapshot env var is undefined, script crashes.

### DIFF
--- a/.buildkite/scripts/resolve_es_treeish.sh
+++ b/.buildkite/scripts/resolve_es_treeish.sh
@@ -7,7 +7,9 @@ VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash
 echo "Fetching versions from $VERSION_URL"
 VERSIONS=$(curl --retry 5 --retry-delay 5 -fsSL $VERSION_URL)
 
-if [[ "$SNAPSHOT" == "true" ]]; then
+snapshot=${SNAPSHOT:-false}
+
+if [[ "$snapshot" == "true" ]]; then
   key=$(echo "$VERSIONS" | jq -r '.snapshots."'"$ELASTIC_STACK_VERSION"'"')
 else
   key=$(echo "$VERSIONS" | jq -r '.releases."'"$ELASTIC_STACK_VERSION"'"')

--- a/.buildkite/scripts/resolve_es_treeish.sh
+++ b/.buildkite/scripts/resolve_es_treeish.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
-set -euo pipefail
+set +u
 
 VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash_releases.json"
 
 echo "Fetching versions from $VERSION_URL"
 VERSIONS=$(curl --retry 5 --retry-delay 5 -fsSL $VERSION_URL)
 
-snapshot=${SNAPSHOT:-false}
-
-if [[ "$snapshot" == "true" ]]; then
+if [[ "$SNAPSHOT" == "true" ]]; then
   key=$(echo "$VERSIONS" | jq -r '.snapshots."'"$ELASTIC_STACK_VERSION"'"')
 else
   key=$(echo "$VERSIONS" | jq -r '.releases."'"$ELASTIC_STACK_VERSION"'"')

--- a/.buildkite/scripts/resolve_es_treeish.sh
+++ b/.buildkite/scripts/resolve_es_treeish.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-set +u
+set -euo pipefail
 
 VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash_releases.json"
 
 echo "Fetching versions from $VERSION_URL"
 VERSIONS=$(curl --retry 5 --retry-delay 5 -fsSL $VERSION_URL)
 
+set +o nounset
 if [[ "$SNAPSHOT" == "true" ]]; then
   key=$(echo "$VERSIONS" | jq -r '.snapshots."'"$ELASTIC_STACK_VERSION"'"')
 else

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -67,9 +67,6 @@ spec:
       skip_intermediate_builds: true
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
-        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
-        SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
-        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
       teams:
         logstash:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
### Description
We define `SNAPSHOT` vars under pipeline env and when it is not defined recently introduced `resolve_es_treeish.sh` script crashes at [this point](https://github.com/elastic/logstash-filter-elastic_integration/blob/main/.buildkite/scripts/resolve_es_treeish.sh#L10). This PR sets default value to `SNAPSHOT` when undefined and allows script to run.