### PR TITLE
E2E pipeline setup with a plugin build shell script.

### DIFF
--- a/.buildkite/e2e-pipeline.yml
+++ b/.buildkite/e2e-pipeline.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+
+agents:
+  provider: gcp
+  imageProject: elastic-images-prod
+  image: family/platform-ingest-logstash-ubuntu-2204
+  machineType: "n2-standard-4"
+  diskSizeGb: 120
+
+steps:
+  # ------------- Run E2E tests ---------------------
+  - label: ":test_tube: Build plugin and run E2E tests :rocket:"
+    command:
+      - .buildkite/scripts/run_e2e_tests.sh
+    env:
+      ELASTIC_STACK_VERSION: "8.x"

--- a/.buildkite/scripts/run_e2e_tests.sh
+++ b/.buildkite/scripts/run_e2e_tests.sh
@@ -21,7 +21,12 @@ resolve_current_stack_version
 ###
 # Build the plugin, to do so we need Logstash source
 build_logstash() {
-  retry -t 5 -- git clone https://github.com/elastic/logstash.git
+  if [[ -d /usr/local/git-references/git-github-com-elastic-logstash-git ]]; then
+      retry -t 5 -- git clone -v --reference /usr/local/git-references/git-github-com-elastic-logstash-git -- https://github.com/elastic/logstash.git .
+  else
+      retry -t 5 -- git clone --single-branch https://github.com/elastic/logstash.git
+  fi
+
   cd logstash && ./gradlew clean bootstrap assemble installDefaultGems && cd ..
   LOGSTASH_PATH=$(pwd)/logstash
   export LOGSTASH_PATH

--- a/.buildkite/scripts/run_e2e_tests.sh
+++ b/.buildkite/scripts/run_e2e_tests.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -euo pipefail
+
+VERSION_URL="https://storage.googleapis.com/artifacts-api/releases/current"
+
+###
+# Resolve stack version and export
+resolve_current_stack_version() {
+  set +o nounset
+
+  local major_version="${ELASTIC_STACK_VERSION%%.*}"
+  local version=$(curl --retry 5 --retry-delay 5 -fsSL "$VERSION_URL/$major_version")
+
+  echo "Resolved version: $version"
+  export STACK_VERSION="$version"
+}
+
+resolve_current_stack_version
+
+###
+# Build the plugin, to do so we need Logstash source
+build_logstash() {
+  retry -t 5 -- git clone https://github.com/elastic/logstash.git
+  cd logstash && ./gradlew clean bootstrap assemble installDefaultGems && cd ..
+  LOGSTASH_PATH=$(pwd)/logstash
+  export LOGSTASH_PATH
+}
+
+build_plugin() {
+  ./gradlew clean vendor localGem
+}
+
+build_logstash
+build_plugin
+
+###
+# TODO: disable ls command and enable with Python E2E scripts
+ls -a
+# Install prerequisites and run E2E tests
+#pip install -r .buildkite/scripts/e2e/requirements.txt
+#python3 .buildkite/scripts/e2e/main.py

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -148,7 +148,7 @@ spec:
     kind: Pipeline
     metadata:
       description: ':logstash: `elastic_integration` E2E tests. :pipeline:'
-      name: logstash-filter-elastic_integration-e2e
+      name: logstash-filter-elastic-integration-e2e
     spec:
       pipeline_file: .buildkite/e2e-pipeline.yml
       maximum_timeout_in_minutes: 120

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -125,3 +125,50 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+# ***********************************
+# SECTION START: E2E tests pipeline
+# ***********************************
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: logstash-filter-elastic-integration-e2e
+  description: 'A pipeline for `elastic_integration` E2E tests.'
+  links:
+    - title: 'A pipeline for `elastic_integration` E2E tests.'
+      url: https://buildkite.com/elastic/logstash-filter-elastic-integration-e2e
+spec:
+  owner: group:ingest-fp
+  type: buildkite-pipeline
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: ':logstash: `elastic_integration` E2E tests. :pipeline:'
+      name: logstash-filter-elastic_integration-e2e
+    spec:
+      pipeline_file: .buildkite/e2e-pipeline.yml
+      maximum_timeout_in_minutes: 120
+      repository: elastic/logstash-filter-elastic_integration
+      env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'true'
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#logstash-build'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+      schedules:
+        Weekly E2E Run:
+          branch: main
+          cronline: "@weekly"
+          message: "Run plugin E2E tests weekly."
+      teams:
+        logstash:
+          access_level: MANAGE_BUILD_AND_READ
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        ingest-eng-prod:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -49,8 +49,8 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      description: ':logstash: The logstash-filter-elastic_integration-pull-request :pipeline:'
-      name: logstash-filter-elastic_integration-pull-request
+      description: ':logstash: Build and test `elastic_integration` pull request :pipeline:'
+      name: logstash-filter-elastic-integration-pull-request
     spec:
       pipeline_file: .buildkite/pull-request-pipeline.yml
       maximum_timeout_in_minutes: 120
@@ -100,8 +100,8 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      description: ':logstash: The logstash-filter-elastic_integration-build :pipeline:'
-      name: logstash-filter-elastic_integration-build
+      description: ':logstash: Build `elastic_integration` with Elasticsearch :pipeline:'
+      name: logstash-filter-elastic-integration-build
     spec:
       pipeline_file: .buildkite/build-pipeline.yml
       maximum_timeout_in_minutes: 120


### PR DESCRIPTION
### Description

This change setups a BK E2E pipeline for `elastic_integration` plugin. It also includes a shell script to build the plugin before E2E tests start (coming soon with https://github.com/elastic/logstash-filter-elastic_integration/pull/122)