### PR TITLE
boundary: use ES API-stable LSIB#createThreadPool

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
@@ -25,6 +25,7 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.ingest.IngestService;
+import org.elasticsearch.ingest.LogstashInternalBridge;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.common.IngestCommonPlugin;
 import org.elasticsearch.ingest.useragent.IngestUserAgentPlugin;
@@ -237,7 +238,7 @@ public class EventProcessorBuilder {
         try {
             final ArrayList<Service> services = new ArrayList<>();
 
-            final ThreadPool threadPool = new ThreadPool(settings);
+            final ThreadPool threadPool = LogstashInternalBridge.createThreadPool(settings);
             resourcesToClose.add(() -> ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS));
 
             final ScriptService scriptService = initScriptService(settings, threadPool);


### PR DESCRIPTION
Introduced on Elasticsearch `main` in elastic/elasticsearch#105163 and backported to `8.12` in elastic/elasticsearch#105163. Migrating to this stable API allows our build to work across the 8.12->8.13 boundary in which we observed a change to the ThreadPool's constructor.

Resolves: elastic/logstash-filter-elastic_integration#120

Closes: #121 