### PR TITLE
Set Java home to the path where Logstash build requires.

### DIFF
--- a/.buildkite/scripts/run_e2e_tests.sh
+++ b/.buildkite/scripts/run_e2e_tests.sh
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:/opt/buildkite-agent/.java/bin:$PATH"
+export JAVA_HOME="/opt/buildkite-agent/.java"
+eval "$(rbenv init -)"
+
 VERSION_URL="https://storage.googleapis.com/artifacts-api/releases/current"
 
 ###


### PR DESCRIPTION
### Description
This change sets Java home to the path and it is required when building Logstash.