### PR TITLE
use reflection to get past breaking change in PainlessPlugin

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
@@ -308,13 +308,36 @@ public class EventProcessorBuilder {
     }
 
     private static ScriptService initScriptService(final Settings settings, final ThreadPool threadPool) {
+        final List<Whitelist> painlessBaseWhitelist = getPainlessBaseWhiteList();
         final Map<ScriptContext<?>, List<Whitelist>> scriptContexts = Map.of(
-                IngestScript.CONTEXT, PainlessPlugin.BASE_WHITELISTS,
-                IngestConditionalScript.CONTEXT, PainlessPlugin.BASE_WHITELISTS);
+                IngestScript.CONTEXT, painlessBaseWhitelist,
+                IngestConditionalScript.CONTEXT, painlessBaseWhitelist);
 
         Map<String, ScriptEngine> engines = new HashMap<>();
         engines.put(PainlessScriptEngine.NAME, new PainlessScriptEngine(settings, scriptContexts));
         engines.put(MustacheScriptEngine.NAME, new MustacheScriptEngine());
         return new ScriptService(settings, engines, ScriptModule.CORE_CONTEXTS, threadPool::absoluteTimeInMillis);
+    }
+
+    /**
+     * @implNote handles breaking changes introduced in Elasticsearch 8.14 series; once 8.14 is
+     *           released and all builds of this plugin depend on Elasticsearch 8.14+, this can
+     *           be simplified to call {@code PainlessPlugin.baseWhiteList()} directly.
+     * @return the PainlessPlugin's default base whitelists
+     */
+    @SuppressWarnings({"JavaReflectionMemberAccess", "unchecked"})
+    static List<Whitelist> getPainlessBaseWhiteList() {
+        Class<PainlessPlugin> cls = PainlessPlugin.class;
+        try {
+            try {
+                // In 8.14+: PainlessPlugin.baseWhiteList()
+                return (List<Whitelist>) cls.getMethod("baseWhiteList").invoke(null);
+            } catch (NoSuchMethodException e) {
+                // in 8.x->8.13.x: PainlessPlugin.BASE_WHITELISTS
+                return (List<Whitelist>) cls.getField("BASE_WHITELISTS").get(null);
+            }
+        } catch (java.lang.reflect.InvocationTargetException | IllegalAccessException | NoSuchFieldException e) {
+            throw new RuntimeException("Unsupported PainlessPlugin does not provide access to its base whitelists", e);
+        }
     }
 }

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilderTest.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilderTest.java
@@ -1,0 +1,19 @@
+package co.elastic.logstash.filters.elasticintegration;
+
+import org.elasticsearch.painless.spi.Whitelist;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+
+class EventProcessorBuilderTest {
+
+    @Test
+    void getPainlessBaseWhiteList() {
+        final List<Whitelist> painlessBaseWhiteList = EventProcessorBuilder.getPainlessBaseWhiteList();
+        assertThat(painlessBaseWhiteList, is(not(empty())));
+    }
+}


### PR DESCRIPTION
One possible approach to handling the upstream breaking change in 8.14's PainlessPlugin's provisioning of default base whitelists.

Resolves #135