### PR TITLE
geoip: implement `GeoIpDatabase` methods added in ES 8.14

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/GeoIpDatabaseAdapter.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/GeoIpDatabaseAdapter.java
@@ -11,9 +11,11 @@ import org.elasticsearch.ingest.geoip.shaded.com.maxmind.db.CHMCache;
 import org.elasticsearch.ingest.geoip.shaded.com.maxmind.db.NodeCache;
 import org.elasticsearch.ingest.geoip.shaded.com.maxmind.geoip2.DatabaseReader;
 import org.elasticsearch.ingest.geoip.shaded.com.maxmind.geoip2.model.AbstractResponse;
+import org.elasticsearch.ingest.geoip.shaded.com.maxmind.geoip2.model.AnonymousIpResponse;
 import org.elasticsearch.ingest.geoip.shaded.com.maxmind.geoip2.model.AsnResponse;
 import org.elasticsearch.ingest.geoip.shaded.com.maxmind.geoip2.model.CityResponse;
 import org.elasticsearch.ingest.geoip.shaded.com.maxmind.geoip2.model.CountryResponse;
+import org.elasticsearch.ingest.geoip.shaded.com.maxmind.geoip2.model.EnterpriseResponse;
 
 import java.io.Closeable;
 import java.io.File;
@@ -50,6 +52,16 @@ public class GeoIpDatabaseAdapter implements GeoIpDatabase, Closeable {
     @Override
     public AsnResponse getAsn(InetAddress inetAddress) {
         return getResponse(inetAddress, this.databaseReader::tryAsn);
+    }
+
+    /* @Override // neither available nor reachable until Elasticsearch 8.14 */
+    public AnonymousIpResponse getAnonymousIp(InetAddress ipAddress) {
+        return getResponse(ipAddress, this.databaseReader::tryAnonymousIp);
+    }
+
+    /* @Override // neither available nor reachable until Elasticsearch 8.14 */
+    public EnterpriseResponse getEnterprise(InetAddress ipAddress) {
+        return getResponse(ipAddress, this.databaseReader::tryEnterprise);
     }
 
     private <T extends AbstractResponse> T getResponse(final InetAddress inetAddress, MaxmindTryLookup<T> resolver) {


### PR DESCRIPTION
Catches up with Elasticsearch 8.14+ support for user-provided databases:
 - `Anonymous-IP` elastic/elasticsearch#107287
 - `Enterprise` elastic/elasticsearch#107377

When compiled against Elasticsearch < 8.14, these methods neither exist in the interface nor are reachable by the GeoIP processor.

Resolves #138 