### PR TITLE
Resolve Logstash container dynamically in E2E tests.

### DIFF
--- a/.buildkite/scripts/e2e/bootstrap.py
+++ b/.buildkite/scripts/e2e/bootstrap.py
@@ -139,7 +139,7 @@ class Bootstrap:
                 commands.extend(["--provider", "serverless"])
             util.run_or_raise_error(commands,
                                     "Error occurred while running stacks with elastic-package. Check logs for details.")
-            time.sleep(10)  # give a time Logstash container fully starts
+            time.sleep(30)  # give a time Logstash container fully starts
         except Exception as ex:
             self.__teardown_stack()  # some containers left running, make sure to stop them
 

--- a/.buildkite/scripts/e2e/bootstrap.py
+++ b/.buildkite/scripts/e2e/bootstrap.py
@@ -134,7 +134,7 @@ class Bootstrap:
     def __spin_stack(self) -> None:
         try:
             # elastic-package stack up -d --version "${ELASTIC_STACK_VERSION}"
-            commands = ["elastic-package", "stack", "up", "-d", "--version", self.stack_version]
+            commands = ["elastic-package", "stack", "up", "-d", "--version", self.stack_version, "-v"]
             if self.project_type == "serverless":
                 commands.extend(["--provider", "serverless"])
             util.run_or_raise_error(commands,

--- a/.buildkite/scripts/e2e/bootstrap.py
+++ b/.buildkite/scripts/e2e/bootstrap.py
@@ -139,6 +139,7 @@ class Bootstrap:
                 commands.extend(["--provider", "serverless"])
             util.run_or_raise_error(commands,
                                     "Error occurred while running stacks with elastic-package. Check logs for details.")
+            time.sleep(10)  # give a time Logstash container fully starts
         except Exception as ex:
             self.__teardown_stack()  # some containers left running, make sure to stop them
 

--- a/.buildkite/scripts/e2e/bootstrap.py
+++ b/.buildkite/scripts/e2e/bootstrap.py
@@ -134,8 +134,7 @@ class Bootstrap:
     def __spin_stack(self) -> None:
         try:
             # elastic-package stack up -d --version "${ELASTIC_STACK_VERSION}"
-            # TODO: remove -v (verbose) option
-            commands = ["elastic-package", "stack", "up", "-d", "--version", self.stack_version, "-v"]
+            commands = ["elastic-package", "stack", "up", "-d", "--version", self.stack_version]
             if self.project_type == "serverless":
                 commands.extend(["--provider", "serverless"])
             util.run_or_raise_error(commands,
@@ -157,10 +156,10 @@ class Bootstrap:
         self.__clone_integrations_repo()
         self.__setup_elastic_package_profile()
         self.__spin_stack()
-        #container = util.get_logstash_container()
-        #self.__install_plugin(container)
-        #self.__reload_container(container)
-        #self.__update_pipeline_config(container)
+        container = util.get_logstash_container()
+        self.__install_plugin(container)
+        self.__reload_container(container)
+        self.__update_pipeline_config(container)
 
     def stop_elastic_stack(self) -> None:
         print(f"Stopping elastic-package stack...")

--- a/.buildkite/scripts/e2e/bootstrap.py
+++ b/.buildkite/scripts/e2e/bootstrap.py
@@ -134,12 +134,13 @@ class Bootstrap:
     def __spin_stack(self) -> None:
         try:
             # elastic-package stack up -d --version "${ELASTIC_STACK_VERSION}"
+            # TODO: remove -v (verbose) option
             commands = ["elastic-package", "stack", "up", "-d", "--version", self.stack_version, "-v"]
             if self.project_type == "serverless":
                 commands.extend(["--provider", "serverless"])
             util.run_or_raise_error(commands,
                                     "Error occurred while running stacks with elastic-package. Check logs for details.")
-            time.sleep(30)  # give a time Logstash container fully starts
+            time.sleep(20)  # give a time Logstash container fully starts
         except Exception as ex:
             self.__teardown_stack()  # some containers left running, make sure to stop them
 

--- a/.buildkite/scripts/e2e/bootstrap.py
+++ b/.buildkite/scripts/e2e/bootstrap.py
@@ -156,10 +156,10 @@ class Bootstrap:
         self.__clone_integrations_repo()
         self.__setup_elastic_package_profile()
         self.__spin_stack()
-        container = util.get_logstash_container()
-        self.__install_plugin(container)
-        self.__reload_container(container)
-        self.__update_pipeline_config(container)
+        #container = util.get_logstash_container()
+        #self.__install_plugin(container)
+        #self.__reload_container(container)
+        #self.__update_pipeline_config(container)
 
     def stop_elastic_stack(self) -> None:
         print(f"Stopping elastic-package stack...")

--- a/.buildkite/scripts/e2e/util.py
+++ b/.buildkite/scripts/e2e/util.py
@@ -21,7 +21,11 @@ def call_url_with_retry(url: str, max_retries: int = 5, delay: int = 1) -> reque
 
 def get_logstash_container() -> Container:
     client = docker.from_env()
-    return client.containers.get("elastic-package-stack-e2e-logstash-1")
+    containers = client.containers.list(all=True)  # we need to use all to collect logs if container stops
+    for container in containers:
+        if "logstash-" in container.name:  # using only "logstash" may catch logstash ready one
+            return container
+    raise Exception("Logstash container not found")
 
 
 def run_or_raise_error(commands: list, error_message):

--- a/.buildkite/scripts/e2e/util.py
+++ b/.buildkite/scripts/e2e/util.py
@@ -21,7 +21,8 @@ def call_url_with_retry(url: str, max_retries: int = 5, delay: int = 1) -> reque
 
 def get_logstash_container() -> Container:
     client = docker.from_env()
-    containers = client.containers.list(all=True)  # we need to use all to collect logs if container stops
+    # `all=True` catches stopped ones as well, we need all to collect logs if container stops abnormally
+    containers = client.containers.list(all=True)
     for container in containers:
         print(f"Container name: {container.name}")
         if "logstash-" in container.name:  # using only "logstash" may catch logstash ready one

--- a/.buildkite/scripts/e2e/util.py
+++ b/.buildkite/scripts/e2e/util.py
@@ -23,7 +23,7 @@ def get_logstash_container() -> Container:
     client = docker.from_env()
     containers = client.containers.list(all=True)  # we need to use all to collect logs if container stops
     for container in containers:
-        print(f"Container name: %s" % container.name)
+        print(f"Container name: {container.name}")
         if "logstash-" in container.name:  # using only "logstash" may catch logstash ready one
             return container
     raise Exception("Logstash container not found")

--- a/.buildkite/scripts/e2e/util.py
+++ b/.buildkite/scripts/e2e/util.py
@@ -23,6 +23,7 @@ def get_logstash_container() -> Container:
     client = docker.from_env()
     containers = client.containers.list(all=True)  # we need to use all to collect logs if container stops
     for container in containers:
+        print(f"Container name: %s" % container.name)
         if "logstash-" in container.name:  # using only "logstash" may catch logstash ready one
             return container
     raise Exception("Logstash container not found")


### PR DESCRIPTION
### Description
Resolve Logstash container dynamically and use it when installing plugin in E2E tests. Before, hard coded container name used, which wasn't failure tolerant.
Example failure: [link](https://buildkite.com/elastic/logstash-filter-elastic-integration-e2e/builds/35#018f45cd-64e3-4ff8-8bb9-dc12d40de347)