### PR TITLE
Allow bot triggered PRs to run CI

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -5,6 +5,7 @@
       "pipelineSlug": "logstash-filter-elastic-integration-pull-request",
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
+      "allowed_list": ["dependabot[bot]", "mergify[bot]"],
       "set_commit_status": true,
       "build_on_commit": true,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

Allow bot triggered PRs to run CI
Relates to issue:
- https://github.com/elastic/ingest-dev/issues/3014
