### PR TITLE
set buildkit progress to plain to reduce CI noise

### DIFF
--- a/.ci/docker-run.sh
+++ b/.ci/docker-run.sh
@@ -5,6 +5,8 @@ set -ex
 
 cd .ci
 
+export BUILDKIT_PROGRESS=plain
+
 if [ "$INTEGRATION" == "true" ]; then
     docker-compose up --exit-code-from logstash
 else

--- a/.ci/docker-setup.sh
+++ b/.ci/docker-setup.sh
@@ -46,6 +46,8 @@ if [ "$ELASTIC_STACK_VERSION" ]; then
 
     cd .ci
 
+    export BUILDKIT_PROGRESS=plain
+
     if [ "$INTEGRATION" == "true" ]; then
         docker-compose down
         docker-compose build


### PR DESCRIPTION
Output of buildkite is too noisy given the docker compose tty progress, it can be heavily reduced by switching to `BUILDKIT_PROGRESS=plain`

Before:

```
❯ ls -lha logstash-filter-elastic-integration-pull-request_build_363_hammer-ci-setup-and-integration-tests-with-es-8-dot-x-snapshot-run-on-docker.log
87M Oct 23 09:30 logstash-filter-elastic-integration-pull-request_build_362_hammer-ci-setup-and-integration-tests-with-es-8-dot-x-run-on-docker.log
```

After:

```
❯ ls -lha logstash-filter-elastic-integration-pull-request_build_362_hammer-ci-setup-and-integration-tests-with-es-8-dot-x-run-on-docker.log
72K Oct 23 09:34 logstash-filter-elastic-integration-pull-request_build_363_hammer-ci-setup-and-integration-tests-with-es-8-dot-x-snapshot-run-on-docker.log
```