### PR TITLE
Use target branch in build CI. Properly name the CI jobs.

### DIFF
--- a/.buildkite/build-pipeline.yml
+++ b/.buildkite/build-pipeline.yml
@@ -8,7 +8,7 @@ agents:
 steps:
   # ------------- Build with ES released versions ---------------------
   # 8.x + (SNAPSHOT=FALSE) -> treeish: v8.11.1  artifact: 8.11.1
-  - label: ":hammer: Build plugin with released Elasticsearch version :elasticsearch:"
+  - label: ":hammer: Build plugin with ES 8.x :elasticsearch:"
     command:
       - .buildkite/scripts/run_tests.sh
     env:
@@ -16,10 +16,14 @@ steps:
       SNAPSHOT: false
       INTEGRATION: true
       SECURE_INTEGRATION: true
+      TARGET_BRANCH: "8.x"
+      # temporary definition to cover PR-170
+      # TODO: remove once 8.16 released
+      ELASTICSEARCH_TREEISH: 8.16
 
   # ------------- Build with ES snapshot versions and main branch ---------------------
   # main + (SNAPSHOT=TRUE) -> treeish: main     artifact:8.12.0-SNAPSHOT
-  - label: ":hammer: Build plugin with Elasticsearch snapshot versions and `main` branch :elasticsearch:"
+  - label: ":hammer: Build plugin with ES `main` branch :elasticsearch:"
     command:
       - .buildkite/scripts/run_tests.sh
     env:

--- a/.buildkite/build-pipeline.yml
+++ b/.buildkite/build-pipeline.yml
@@ -6,9 +6,9 @@ agents:
   image: family/core-ubuntu-2204
 
 steps:
-  # ------------- Build with ES released versions ---------------------
-  # 8.x + (SNAPSHOT=FALSE) -> treeish: v8.11.1  artifact: 8.11.1
-  - label: ":hammer: Build plugin with ES 8.x :elasticsearch:"
+  - label: ":hammer: Build plugin with LS & ES 8.x :elasticsearch:"
+    # Builds with LS and ES last 8.x released version
+    # Runs integration tests on 8.x released versions
     command:
       - .buildkite/scripts/run_tests.sh
     env:
@@ -21,13 +21,25 @@ steps:
       # TODO: remove once 8.16 released
       ELASTICSEARCH_TREEISH: 8.16
 
-  # ------------- Build with ES snapshot versions and main branch ---------------------
-  # main + (SNAPSHOT=TRUE) -> treeish: main     artifact:8.12.0-SNAPSHOT
-  - label: ":hammer: Build plugin with ES `main` branch :elasticsearch:"
+  - label: ":hammer: Build plugin with LS 8.x-SNAPSHOT & ES `main` branch :elasticsearch:"
+    # Builds with LS last 8.x released version and ES main
+    # Runs integration tests on 8.x released versions
     command:
       - .buildkite/scripts/run_tests.sh
     env:
       ELASTIC_STACK_VERSION: "8.x"
+      ELASTICSEARCH_TREEISH: "main"
+      SNAPSHOT: true
+      INTEGRATION: true
+      SECURE_INTEGRATION: true
+
+  - label: ":hammer: Build plugin with LS & ES `main` branch :elasticsearch:"
+    # Builds with LS last 8.x released version and ES main
+    # Runs integration tests on 8.x released versions
+    command:
+      - .buildkite/scripts/run_tests.sh
+    env:
+      ELASTIC_STACK_VERSION: "main"
       ELASTICSEARCH_TREEISH: "main"
       SNAPSHOT: true
       INTEGRATION: true

--- a/.buildkite/e2e-pipeline.yml
+++ b/.buildkite/e2e-pipeline.yml
@@ -3,7 +3,7 @@
 agents:
   provider: gcp
   imageProject: elastic-images-prod
-  image: family/platform-ingest-logstash-ubuntu-2204
+  image: family/platform-ingest-logstash-multi-jdk-ubuntu-2204
   machineType: "n2-standard-4"
   diskSizeGb: 120
 

--- a/.buildkite/e2e-pipeline.yml
+++ b/.buildkite/e2e-pipeline.yml
@@ -9,8 +9,9 @@ agents:
 
 steps:
   # ------------- Run E2E tests ---------------------
-  - label: ":test_tube: Build plugin and run E2E tests :rocket:"
+  - label: ":test_tube: Run E2E tests with LS 8.x :rocket:"
     command:
       - .buildkite/scripts/run_e2e_tests.sh
     env:
       ELASTIC_STACK_VERSION: "8.x"
+      TARGET_BRANCH: "8.x"

--- a/.buildkite/e2e-pipeline.yml
+++ b/.buildkite/e2e-pipeline.yml
@@ -15,3 +15,11 @@ steps:
     env:
       ELASTIC_STACK_VERSION: "8.x"
       TARGET_BRANCH: "8.x"
+
+  - label: ":test_tube: Run E2E tests with LS 8.x-SNAPSHOT :rocket:"
+    command:
+      - .buildkite/scripts/run_e2e_tests.sh
+    env:
+      # uses the plugin main branch with JDK21 requirement
+      ELASTIC_STACK_VERSION: "8.x"
+      SNAPSHOT: true

--- a/.buildkite/e2e-pipeline.yml
+++ b/.buildkite/e2e-pipeline.yml
@@ -10,6 +10,8 @@ agents:
 steps:
   # ------------- Run E2E tests ---------------------
   - label: ":test_tube: Run E2E tests with LS 8.x :rocket:"
+    # uses the LS main & plugin 8.x branch when building the plugin
+    # Runs integration tests against 8.x release version
     command:
       - .buildkite/scripts/run_e2e_tests.sh
     env:
@@ -17,9 +19,20 @@ steps:
       TARGET_BRANCH: "8.x"
 
   - label: ":test_tube: Run E2E tests with LS 8.x-SNAPSHOT :rocket:"
+    # uses the LS & plugin main branch when building the plugin
+    # Runs integration tests against 8.x-SNAPSHOT version
     command:
       - .buildkite/scripts/run_e2e_tests.sh
     env:
-      # uses the plugin main branch with JDK21 requirement
       ELASTIC_STACK_VERSION: "8.x"
       SNAPSHOT: true
+
+  - label: ":test_tube: Run E2E tests with LS `main` :rocket:"
+    # uses the LS & plugin main branch when building the plugin
+    # Runs integration tests against snapshot.main of https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash_releases.json
+    command:
+      - .buildkite/scripts/run_e2e_tests.sh
+    env:
+      ELASTIC_STACK_VERSION: main
+      SNAPSHOT: true
+      ELASTICSEARCH_TREEISH: main

--- a/.buildkite/pull-request-pipeline.yml
+++ b/.buildkite/pull-request-pipeline.yml
@@ -7,24 +7,30 @@ agents:
 steps:
   # ------------- Unit tests ---------------------
   - label: ":hammer: Unit tests with LS & ES 8.x-SNAPSHOT :docker:"
+    # Builds the plugin (with current changes) against LS 8.x-SNAPSHOT and ES version defined in gradle.properties
+    # Runs unit tests on LS & ES 8.x-SNAPSHOT docker
     command:
       - .buildkite/scripts/run_tests.sh
     env:
       ELASTIC_STACK_VERSION: "8.x"
-      INTEGRATION: false
       SNAPSHOT: true
+      INTEGRATION: false
 
   - label: ":hammer: Unit tests with LS 8.x-SNAPSHOT & ES main :docker:"
+    # Builds the plugin (with current changes) against LS 8.x-SNAPSHOT and ES main
+    # Runs unit tests on LS & ES 8.x-SNAPSHOT docker
     command:
       - .buildkite/scripts/run_tests.sh
     env:
       ELASTIC_STACK_VERSION: "8.x"
+      ELASTICSEARCH_TREEISH: main
       INTEGRATION: false
       SNAPSHOT: true
-      ELASTICSEARCH_TREEISH: main
 
   # ------------- Integration tests ---------------------
   - label: ":hammer: Integration tests with LS & ES 8.x :docker:"
+    # Builds the plugin (with current changes) against LS 8.x and ES version defined in gradle.properties
+    # Runs integration tests on LS & ES 8.x docker
     command:
       - .buildkite/scripts/run_tests.sh
     env:
@@ -36,22 +42,39 @@ steps:
       ELASTICSEARCH_TREEISH: 8.16
 
   - label: ":hammer: Integration tests with LS & ES 8.x-SNAPSHOT :docker:"
+    # Builds the plugin (with current changes) against LS 8.x-SNAPSHOT and ES version defined in gradle.properties
+    # Runs integration tests on LS & ES 8.x-SNAPSHOT docker
     command:
       - .buildkite/scripts/run_tests.sh
     env:
       ELASTIC_STACK_VERSION: "8.x"
-      INTEGRATION: true
-      LOG_LEVEL: "info"
-      SECURE_INTEGRATION: true
       SNAPSHOT: true
+      INTEGRATION: true
+      SECURE_INTEGRATION: true
+      LOG_LEVEL: "info"
 
   - label: ":hammer: Integration tests with LS 8.x-SNAPSHOT & ES main :docker:"
+    # Builds the plugin (with current changes) against LS 8.x-SNAPSHOT and ES main
+    # Runs integration tests on LS & ES 8.x-SNAPSHOT docker
     command:
       - .buildkite/scripts/run_tests.sh
     env:
       ELASTIC_STACK_VERSION: "8.x"
-      INTEGRATION: true
-      LOG_LEVEL: "info"
-      SECURE_INTEGRATION: true
+      ELASTICSEARCH_TREEISH: "main"
       SNAPSHOT: true
+      INTEGRATION: true
+      SECURE_INTEGRATION: true
+      LOG_LEVEL: "info"
+
+  - label: ":hammer: Integration tests with LS & ES main :docker:"
+    # Builds the plugin (with current changes) against LS and ES main
+    # Runs integration tests on snapshot.main of https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash_releases.json
+    command:
+      - .buildkite/scripts/run_tests.sh
+    env:
+      ELASTIC_STACK_VERSION: main
       ELASTICSEARCH_TREEISH: main
+      SNAPSHOT: true
+      INTEGRATION: true
+      SECURE_INTEGRATION: true
+      LOG_LEVEL: "info"

--- a/.buildkite/pull-request-pipeline.yml
+++ b/.buildkite/pull-request-pipeline.yml
@@ -14,6 +14,15 @@ steps:
       INTEGRATION: false
       SNAPSHOT: true
 
+  - label: ":hammer: Unit tests with LS 8.x-SNAPSHOT & ES main :docker:"
+    command:
+      - .buildkite/scripts/run_tests.sh
+    env:
+      ELASTIC_STACK_VERSION: "8.x"
+      INTEGRATION: false
+      SNAPSHOT: true
+      ELASTICSEARCH_TREEISH: main
+
   # ------------- Integration tests ---------------------
   - label: ":hammer: Integration tests with LS & ES 8.x :docker:"
     command:
@@ -35,3 +44,14 @@ steps:
       LOG_LEVEL: "info"
       SECURE_INTEGRATION: true
       SNAPSHOT: true
+
+  - label: ":hammer: Integration tests with LS 8.x-SNAPSHOT & ES main :docker:"
+    command:
+      - .buildkite/scripts/run_tests.sh
+    env:
+      ELASTIC_STACK_VERSION: "8.x"
+      INTEGRATION: true
+      LOG_LEVEL: "info"
+      SECURE_INTEGRATION: true
+      SNAPSHOT: true
+      ELASTICSEARCH_TREEISH: main

--- a/.buildkite/pull-request-pipeline.yml
+++ b/.buildkite/pull-request-pipeline.yml
@@ -6,7 +6,7 @@ agents:
 
 steps:
   # ------------- Unit tests ---------------------
-  - label: ":hammer: CI setup and unit tests run :docker:"
+  - label: ":hammer: Unit tests with LS & ES 8.x-SNAPSHOT :docker:"
     command:
       - .buildkite/scripts/run_tests.sh
     env:
@@ -15,7 +15,7 @@ steps:
       SNAPSHOT: true
 
   # ------------- Integration tests ---------------------
-  - label: ":hammer: CI setup and integration tests with ES 8.x run on :docker:"
+  - label: ":hammer: Integration tests with LS & ES 8.x :docker:"
     command:
       - .buildkite/scripts/run_tests.sh
     env:
@@ -26,7 +26,7 @@ steps:
       # TODO: remove once 8.16 released
       ELASTICSEARCH_TREEISH: 8.16
 
-  - label: ":hammer: CI setup and integration tests with ES 8.x-SNAPSHOT run on :docker:"
+  - label: ":hammer: Integration tests with LS & ES 8.x-SNAPSHOT :docker:"
     command:
       - .buildkite/scripts/run_tests.sh
     env:

--- a/.buildkite/scripts/run_e2e_tests.sh
+++ b/.buildkite/scripts/run_e2e_tests.sh
@@ -12,6 +12,7 @@ VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash
 ###
 # Checkout the target branch if defined
 checkout_target_branch() {
+  set +o nounset
   if [ -z "$TARGET_BRANCH" ]; then
     echo "Target branch is not specified, using default branch: main or BK defined"
   else
@@ -23,15 +24,16 @@ checkout_target_branch() {
 ###
 # Resolve stack version and export
 resolve_current_stack_version() {
-   echo "Fetching versions from $VERSION_URL"
-   VERSIONS=$(curl --retry 5 --retry-delay 5 -fsSL $VERSION_URL)
+  set +o nounset
+  echo "Fetching versions from $VERSION_URL"
+  VERSIONS=$(curl --retry 5 --retry-delay 5 -fsSL $VERSION_URL)
 
-   if [[ "$SNAPSHOT" == "true" ]]; then
-     key=$(echo "$VERSIONS" | jq -r '.snapshots."'"$ELASTIC_STACK_VERSION"'"')
-     echo "resolved key: $key"
-   else
-     key=$(echo "$VERSIONS" | jq -r '.releases."'"$ELASTIC_STACK_VERSION"'"')
-   fi
+  if [[ "$SNAPSHOT" == "true" ]]; then
+    key=$(echo "$VERSIONS" | jq -r '.snapshots."'"$ELASTIC_STACK_VERSION"'"')
+    echo "resolved key: $key"
+  else
+    key=$(echo "$VERSIONS" | jq -r '.releases."'"$ELASTIC_STACK_VERSION"'"')
+  fi
 
   echo "Resolved version: $key"
   export STACK_VERSION="$key"

--- a/.buildkite/scripts/run_e2e_tests.sh
+++ b/.buildkite/scripts/run_e2e_tests.sh
@@ -10,6 +10,17 @@ eval "$(pyenv init -)"
 VERSION_URL="https://storage.googleapis.com/artifacts-api/releases/current"
 
 ###
+# Checkout the target branch if defined
+checkout_target_branch() {
+  if [ -z "$TARGET_BRANCH" ]; then
+    echo "Target branch is not specified, using default branch: main or BK defined"
+  else
+    echo "Changing the branch for ${TARGET_BRANCH}"
+    git checkout "$TARGET_BRANCH"
+  fi
+}
+
+###
 # Resolve stack version and export
 resolve_current_stack_version() {
   set +o nounset
@@ -41,6 +52,7 @@ build_plugin() {
   ./gradlew clean vendor localGem
 }
 
+checkout_target_branch
 build_logstash
 build_plugin
 

--- a/.buildkite/scripts/run_e2e_tests.sh
+++ b/.buildkite/scripts/run_e2e_tests.sh
@@ -42,11 +42,13 @@ set_required_jdk() {
   set +o nounset
   java_version="$(cat .java-version)"
   echo "Required JDK version: $java_version"
-  if [[ "$java_version" == "21.0" ]]; then
-    echo "Setting JDK version to $java_version"
+  if [[ "$java_version" == "17.0" ]]; then
+    jdk_home="/opt/buildkite-agent/.java/adoptiumjdk_17"
+  elif [[ "$java_version" == "21.0" ]]; then
     jdk_home="/opt/buildkite-agent/.java/adoptiumjdk_21"
   else
-    jdk_home="/opt/buildkite-agent/.java"
+    echo "Unsupported JDK."
+    exit 1
   fi
 
   export JAVA_HOME=$jdk_home

--- a/.buildkite/scripts/run_e2e_tests.sh
+++ b/.buildkite/scripts/run_e2e_tests.sh
@@ -2,24 +2,11 @@
 
 set -euo pipefail
 
-export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:/opt/buildkite-agent/.java/bin:$PATH"
-export JAVA_HOME="/opt/buildkite-agent/.java"
+export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:$PATH"
 eval "$(rbenv init -)"
 eval "$(pyenv init -)"
 
 VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash_releases.json"
-
-###
-# Checkout the target branch if defined
-checkout_target_branch() {
-  set +o nounset
-  if [ -z "$TARGET_BRANCH" ]; then
-    echo "Target branch is not specified, using default branch: main or BK defined"
-  else
-    echo "Changing the branch for ${TARGET_BRANCH}"
-    git checkout "$TARGET_BRANCH"
-  fi
-}
 
 ###
 # Resolve stack version and export
@@ -39,7 +26,32 @@ resolve_current_stack_version() {
   export STACK_VERSION="$key"
 }
 
-resolve_current_stack_version
+###
+# Checkout the target branch if defined
+checkout_target_branch() {
+  set +o nounset
+  if [ -z "$TARGET_BRANCH" ]; then
+    echo "Target branch is not specified, using default branch: main or BK defined"
+  else
+    echo "Changing the branch for ${TARGET_BRANCH}"
+    git checkout "$TARGET_BRANCH"
+  fi
+}
+
+set_required_jdk() {
+  set +o nounset
+  java_version="$(cat .java-version)"
+  echo "Required JDK version: $java_version"
+  if [[ "$java_version" == "21.0" ]]; then
+    echo "Setting JDK version to $java_version"
+    jdk_home="/opt/buildkite-agent/.java/adoptiumjdk_21"
+  else
+    jdk_home="/opt/buildkite-agent/.java"
+  fi
+
+  export JAVA_HOME=$jdk_home
+  export PATH="$jdk_home:$PATH"
+}
 
 ###
 # Build the plugin, to do so we need Logstash source
@@ -59,7 +71,9 @@ build_plugin() {
   ./gradlew clean vendor localGem
 }
 
+resolve_current_stack_version
 checkout_target_branch
+set_required_jdk
 build_logstash
 build_plugin
 

--- a/.buildkite/scripts/run_tests.sh
+++ b/.buildkite/scripts/run_tests.sh
@@ -5,4 +5,11 @@ else
   echo "Using ELASTICSEARCH_TREEISH ${ELASTICSEARCH_TREEISH} defined in the ENV."
 fi
 
+if [ -z "$TARGET_BRANCH" ]; then
+  echo "Target branch is not specified, using default branch: main or BK defined"
+else
+  echo "Changing the branch for ${TARGET_BRANCH}"
+  git checkout "$TARGET_BRANCH"
+fi
+
 mkdir -p .ci && curl -sL --retry 5 --retry-delay 5 https://github.com/logstash-plugins/.ci/archive/buildkite-1.x.tar.gz | tar zxvf - --skip-old-files --strip-components=1 -C .ci --wildcards '*Dockerfile*' '*docker*' '*.sh' && .ci/docker-setup.sh && .ci/docker-run.sh


### PR DESCRIPTION
### Description
- Introduces a change to use the 8.x branch in build CI.
- Renames the CI jobs to provide proper names

More deeper details about these compatibility concept here:

- with build CI: make sure we keep the plugin compatible with
   - a) any new 8.x releases
   - b) any changes going to be in upcoming future 8.x/minor releases (LS 8.x-SNAPSHOT vs ES main, we may use ES 8.x-SNAPSHOT but we cover it with a) as we are defining the branch in gradle.properties)
   - c) any changes going to be in upcoming future major releases (LS main vs ES main)
- with E2E: make sure the plugin doesn't have an issue when running integrations
   - a) on across 8.x stack
   - b) on across 8.x-SNAPSHOT stack
   - c) on main (or future major version)
- with PR CI: every change introduced under the PR should be compatible across
   - a) current release, granularity LS 8.x vs (ES 8x and ES 8.x-SNAPSHOT)
   - b) upcoming release LS 8.x-SNAPSHOT vs (ES 8.x-SNAPSHOT and ES main)
   - c) upcoming major LS & ES main

Latest CI runs:
- PR: https://buildkite.com/elastic/logstash-filter-elastic-integration-pull-request/builds/375
- Build: https://buildkite.com/elastic/logstash-filter-elastic-integration-build/builds/400
- E2E: https://buildkite.com/elastic/logstash-filter-elastic-integration-e2e/builds/102

### Author's checklist
- [ ] After merge, (nothing functional change but) let's backport to `8.x`