### PR TITLE
geoip: managed databases need to be closed when updated

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/ConstantIpDatabaseHolder.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/ConstantIpDatabaseHolder.java
@@ -19,7 +19,7 @@ public class ConstantIpDatabaseHolder implements IpDatabaseHolder, Closeable {
     }
 
     @Override
-    public IpDatabase getDatabase() {
+    public IpDatabaseAdapter getDatabase() {
         return this.ipDatabase;
     }
 

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/IpDatabaseAdapter.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/IpDatabaseAdapter.java
@@ -27,6 +27,8 @@ public class IpDatabaseAdapter implements IpDatabase {
     private final Reader databaseReader;
     private final String databaseType;
 
+    private volatile boolean isReaderClosed = false;
+
     public IpDatabaseAdapter(final Reader databaseReader) {
         this.databaseReader = databaseReader;
         this.databaseType = databaseReader.getMetadata().getDatabaseType();
@@ -56,6 +58,12 @@ public class IpDatabaseAdapter implements IpDatabase {
     public void closeReader() throws IOException {
         LOGGER.debug("Closing the database adapter");
         this.databaseReader.close();
+        this.isReaderClosed = true;
+    }
+
+    // visible for test
+    boolean isReaderClosed() {
+        return this.isReaderClosed;
     }
 
     public static IpDatabaseAdapter defaultForPath(final Path database) throws IOException {

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/IpDatabaseHolder.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/IpDatabaseHolder.java
@@ -5,7 +5,7 @@ import org.elasticsearch.ingest.geoip.IpDatabase;
 interface IpDatabaseHolder {
     boolean isValid();
 
-    IpDatabase getDatabase();
+    IpDatabaseAdapter getDatabase();
 
     String getTypeIdentifier();
 

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/IpDatabaseProvider.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/IpDatabaseProvider.java
@@ -34,18 +34,23 @@ public class IpDatabaseProvider implements org.elasticsearch.ingest.geoip.IpData
 
     @Override
     public Boolean isValid(String databaseIdentifierFileName) {
-        final IpDatabaseHolder holder = databaseMap.get(databaseIdentifierFileName);
+        final IpDatabaseHolder holder = getDatabaseHolder(databaseIdentifierFileName);
         return Objects.nonNull(holder) && holder.isValid();
     }
 
     @Override
     public IpDatabase getDatabase(String databaseIdentifierFileName) {
-        final IpDatabaseHolder holder = databaseMap.get(databaseIdentifierFileName);
+        final IpDatabaseHolder holder = getDatabaseHolder(databaseIdentifierFileName);
         if (Objects.isNull(holder)) {
             return null;
         } else {
             return holder.getDatabase();
         }
+    }
+
+    // visible for test
+    IpDatabaseHolder getDatabaseHolder(String databaseIdentifierFileName) {
+        return databaseMap.get(databaseIdentifierFileName);
     }
 
     @Override

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/geoip/ManagedIpDatabaseHolderTest.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/geoip/ManagedIpDatabaseHolderTest.java
@@ -1,0 +1,78 @@
+package co.elastic.logstash.filters.elasticintegration.geoip;
+
+import co.elastic.logstash.filters.elasticintegration.util.ResourcesUtil;
+import org.apache.commons.io.FilenameUtils;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+class ManagedIpDatabaseHolderTest {
+    static final Path GEOLITE2_ASN_MMDB_PATH;
+    static final Path GEOLITE2_CITY_MMDB_PATH;
+
+    static final String GEOLITE2_ASN_TYPE = "GeoLite2-ASN.mmdb";
+    static final String GEOLITE2_CITY_TYPE = "GeoLite2-City.mmdb";
+
+    static {
+        try {
+            final Path databases = ResourcesUtil.getResourcePath(ManagedIpDatabaseHolderTest.class, "databases").orElseThrow();
+            GEOLITE2_ASN_MMDB_PATH = databases.resolve(GEOLITE2_ASN_TYPE).toRealPath();
+            GEOLITE2_CITY_MMDB_PATH = databases.resolve(GEOLITE2_CITY_TYPE).toRealPath();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    IpDatabaseProvider buildIpDatabaseProvider(final Path... paths) {
+        final IpDatabaseProvider.Builder builder = new IpDatabaseProvider.Builder();
+        for (Path path : paths) {
+            final String databaseFileName = path.getFileName().toString();
+            final String databaseTypeIdentifier = FilenameUtils.removeExtension(databaseFileName);
+            @SuppressWarnings("resource") final ManagedIpDatabaseHolder dbh = new ManagedIpDatabaseHolder(databaseTypeIdentifier, path);
+            builder.setDatabaseHolder(databaseFileName, dbh);
+        }
+        return builder.build();
+    }
+
+    @Test
+    void releaseOnReload() throws Exception {
+        try (IpDatabaseProvider ipDatabaseProvider = buildIpDatabaseProvider(GEOLITE2_CITY_MMDB_PATH)) {
+            final IpDatabaseHolder cityIpDatabaseHolder = ipDatabaseProvider.getDatabaseHolder(GEOLITE2_CITY_TYPE);
+            assert cityIpDatabaseHolder instanceof ManagedIpDatabaseHolder;
+
+            final IpDatabaseAdapter first = cityIpDatabaseHolder.getDatabase();
+            assertFalse(first.isReaderClosed());
+
+            // update the holder's path. It's okay to be the same underlying file.
+            ((ManagedIpDatabaseHolder) cityIpDatabaseHolder).setDatabasePath(GEOLITE2_CITY_MMDB_PATH.toString());
+
+            // get the database again, and make sure we have a new open one, and that the old one has been closed
+            final IpDatabaseAdapter second = cityIpDatabaseHolder.getDatabase();
+            assertNotEquals(first, second);
+            assertTrue(first.isReaderClosed());
+            assertFalse(second.isReaderClosed());
+        }
+    }
+
+    @Test
+    void rejectTypeChangeOnReload() throws Exception {
+        try (IpDatabaseProvider ipDatabaseProvider = buildIpDatabaseProvider(GEOLITE2_CITY_MMDB_PATH)) {
+            final IpDatabaseHolder cityIpDatabaseHolder = ipDatabaseProvider.getDatabaseHolder(GEOLITE2_CITY_TYPE);
+            assert cityIpDatabaseHolder instanceof ManagedIpDatabaseHolder;
+
+            final IpDatabaseAdapter first = cityIpDatabaseHolder.getDatabase();
+            assertFalse(first.isReaderClosed());
+
+            // update the holder's path to the wrong type
+            IllegalStateException illegalStateException = assertThrows(IllegalStateException.class, () -> {
+                ((ManagedIpDatabaseHolder) cityIpDatabaseHolder).setDatabasePath(GEOLITE2_ASN_MMDB_PATH.toString());
+            });
+            assertThat(illegalStateException.getMessage(), Matchers.containsString("Incompatible database type `GeoLite2-ASN` (expected `GeoLite2-City`)"));
+        }
+    }
+}


### PR DESCRIPTION
This is a follow-up to https://github.com/elastic/logstash-filter-elastic_integration/pull/170#pullrequestreview-2400287935, as applied to 8.x

It will need to be forward-ported to `main`.