### PR TITLE
prevent releases from `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## UNRELEASED
+  - Releases from `main` are not desired until we get closer to Stack 9.x, and beginning the changelog with something other than release notes matching the version will prevent the plugin release tooling from allowing publication.
+
 ## 0.1.16
   - Reflects the Elasticsearch GeoIP changes into the plugin and syncs with Elasticsearch 8.16 branch [#170](https://github.com/elastic/logstash-filter-elastic_integration/pull/170)
 


### PR DESCRIPTION
The publisher workflow requires that the `CHANGELOG.md` leads with an entry matching the version, so this will prevent releases on the `main` branch, as desired until we come up with the publish path for Elastic Stack 9.x