### PR TITLE
Fix the CI failures after version definitions in .ci repo.

### DIFF
--- a/.buildkite/build-pipeline.yml
+++ b/.buildkite/build-pipeline.yml
@@ -12,14 +12,11 @@ steps:
     command:
       - .buildkite/scripts/run_tests.sh
     env:
-      ELASTIC_STACK_VERSION: "8.x"
+      ELASTIC_STACK_VERSION: "8.current"
       SNAPSHOT: false
       INTEGRATION: true
       SECURE_INTEGRATION: true
       TARGET_BRANCH: "8.x"
-      # temporary definition to cover PR-170
-      # TODO: remove once 8.16 released
-      ELASTICSEARCH_TREEISH: 8.16
 
   - label: ":hammer: Build plugin with LS 8.x-SNAPSHOT & ES `main` branch :elasticsearch:"
     # Builds with LS last 8.x released version and ES main
@@ -27,7 +24,7 @@ steps:
     command:
       - .buildkite/scripts/run_tests.sh
     env:
-      ELASTIC_STACK_VERSION: "8.x"
+      ELASTIC_STACK_VERSION: "8.current"
       ELASTICSEARCH_TREEISH: "main"
       SNAPSHOT: true
       INTEGRATION: true

--- a/.buildkite/e2e-pipeline.yml
+++ b/.buildkite/e2e-pipeline.yml
@@ -15,7 +15,7 @@ steps:
     command:
       - .buildkite/scripts/run_e2e_tests.sh
     env:
-      ELASTIC_STACK_VERSION: "8.x"
+      ELASTIC_STACK_VERSION: "8.current"
       TARGET_BRANCH: "8.x"
 
   - label: ":test_tube: Run E2E tests with LS 8.x-SNAPSHOT :rocket:"
@@ -24,7 +24,7 @@ steps:
     command:
       - .buildkite/scripts/run_e2e_tests.sh
     env:
-      ELASTIC_STACK_VERSION: "8.x"
+      ELASTIC_STACK_VERSION: "8.current"
       SNAPSHOT: true
 
   - label: ":test_tube: Run E2E tests with LS `main` :rocket:"

--- a/.buildkite/pull-request-pipeline.yml
+++ b/.buildkite/pull-request-pipeline.yml
@@ -12,7 +12,7 @@ steps:
     command:
       - .buildkite/scripts/run_tests.sh
     env:
-      ELASTIC_STACK_VERSION: "8.x"
+      ELASTIC_STACK_VERSION: "8.current"
       SNAPSHOT: true
       INTEGRATION: false
 
@@ -22,7 +22,7 @@ steps:
     command:
       - .buildkite/scripts/run_tests.sh
     env:
-      ELASTIC_STACK_VERSION: "8.x"
+      ELASTIC_STACK_VERSION: "8.current"
       ELASTICSEARCH_TREEISH: main
       INTEGRATION: false
       SNAPSHOT: true
@@ -34,12 +34,9 @@ steps:
     command:
       - .buildkite/scripts/run_tests.sh
     env:
-      ELASTIC_STACK_VERSION: "8.x"
+      ELASTIC_STACK_VERSION: "8.current"
       INTEGRATION: true
       SECURE_INTEGRATION: true
-      # temporary definition to cover PR-170
-      # TODO: remove once 8.16 released
-      ELASTICSEARCH_TREEISH: 8.16
 
   - label: ":hammer: Integration tests with LS & ES 8.x-SNAPSHOT :docker:"
     # Builds the plugin (with current changes) against LS 8.x-SNAPSHOT and ES version defined in gradle.properties
@@ -47,7 +44,7 @@ steps:
     command:
       - .buildkite/scripts/run_tests.sh
     env:
-      ELASTIC_STACK_VERSION: "8.x"
+      ELASTIC_STACK_VERSION: "8.current"
       SNAPSHOT: true
       INTEGRATION: true
       SECURE_INTEGRATION: true
@@ -59,7 +56,7 @@ steps:
     command:
       - .buildkite/scripts/run_tests.sh
     env:
-      ELASTIC_STACK_VERSION: "8.x"
+      ELASTIC_STACK_VERSION: "8.current"
       ELASTICSEARCH_TREEISH: "main"
       SNAPSHOT: true
       INTEGRATION: true

--- a/.ci/docker-run.sh
+++ b/.ci/docker-run.sh
@@ -8,7 +8,7 @@ cd .ci
 export BUILDKIT_PROGRESS=plain
 
 if [ "$INTEGRATION" == "true" ]; then
-    docker-compose up --exit-code-from logstash
+    docker compose up --exit-code-from logstash
 else
-    docker-compose up --exit-code-from logstash logstash
+    docker compose up --exit-code-from logstash logstash
 fi

--- a/.ci/docker-setup.sh
+++ b/.ci/docker-setup.sh
@@ -49,11 +49,11 @@ if [ "$ELASTIC_STACK_VERSION" ]; then
     export BUILDKIT_PROGRESS=plain
 
     if [ "$INTEGRATION" == "true" ]; then
-        docker-compose down
-        docker-compose build
+        docker compose down
+        docker compose build
     else
-        docker-compose down
-        docker-compose build logstash
+        docker compose down
+        docker compose build logstash
     fi
 else
     echo "Please set the ELASTIC_STACK_VERSION environment variable"


### PR DESCRIPTION
Backporting https://github.com/elastic/logstash-filter-elastic_integration/pull/185 into 8.x