### PR TITLE
Sync up with ES main on `PipelineConfiguration` class changes.

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestPipelineFactory.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestPipelineFactory.java
@@ -46,7 +46,7 @@ public class IngestPipelineFactory {
 
     public Optional<IngestPipeline> create(final PipelineConfiguration pipelineConfiguration) {
         try {
-            final Pipeline pipeline = Pipeline.create(pipelineConfiguration.getId(), pipelineConfiguration.getConfig(), processorFactories, scriptService);
+            final Pipeline pipeline = Pipeline.create(pipelineConfiguration.getId(), pipelineConfiguration.getConfig(false), processorFactories, scriptService);
             final IngestPipeline ingestPipeline = new IngestPipeline(pipelineConfiguration, pipeline);
             LOGGER.debug(() -> String.format("successfully created ingest pipeline `%s` from pipeline configuration", pipelineConfiguration.getId()));
             return Optional.of(ingestPipeline);

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestPipelineFactory.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/IngestPipelineFactory.java
@@ -46,7 +46,7 @@ public class IngestPipelineFactory {
 
     public Optional<IngestPipeline> create(final PipelineConfiguration pipelineConfiguration) {
         try {
-            final Pipeline pipeline = Pipeline.create(pipelineConfiguration.getId(), pipelineConfiguration.getConfigAsMap(), processorFactories, scriptService);
+            final Pipeline pipeline = Pipeline.create(pipelineConfiguration.getId(), pipelineConfiguration.getConfig(), processorFactories, scriptService);
             final IngestPipeline ingestPipeline = new IngestPipeline(pipelineConfiguration, pipeline);
             LOGGER.debug(() -> String.format("successfully created ingest pipeline `%s` from pipeline configuration", pipelineConfiguration.getId()));
             return Optional.of(ingestPipeline);

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/ElasticsearchPipelineConfigurationResolverTest.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/ElasticsearchPipelineConfigurationResolverTest.java
@@ -59,7 +59,7 @@ class ElasticsearchPipelineConfigurationResolverTest {
             assertThat(resolvedPipelineConfiguration, isPresent());
             resolvedPipelineConfiguration.ifPresent(pipelineConfiguration -> {
                 assertThat(pipelineConfiguration.getId(), is(equalTo("my-pipeline-id")));
-                final Map<String, Object> configAsMap = pipelineConfiguration.getConfigAsMap();
+                final Map<String, Object> configAsMap = pipelineConfiguration.getConfig();
                 assertThat(configAsMap, is(equalTo(EXPECTED_MY_PIPELINE_ID_CONFIG_MAP)));
             });
         });
@@ -77,7 +77,7 @@ class ElasticsearchPipelineConfigurationResolverTest {
             assertThat(resolvedPipelineConfiguration, isPresent());
             resolvedPipelineConfiguration.ifPresent(pipelineConfiguration -> {
                 assertThat(pipelineConfiguration.getId(), is(equalTo("special char pipeline")));
-                final Map<String, Object> configAsMap = pipelineConfiguration.getConfigAsMap();
+                final Map<String, Object> configAsMap = pipelineConfiguration.getConfig();
                 assertThat(configAsMap, is(equalTo(EXPECTED_MY_PIPELINE_ID_CONFIG_MAP)));
             });
         });

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/PipelineConfigurationFactoryTest.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/PipelineConfigurationFactoryTest.java
@@ -44,7 +44,7 @@ class PipelineConfigurationFactoryTest {
         final PipelineConfiguration loaded = PipelineConfigurationFactory.getInstance().parseNamedObject(json);
         assertThat(loaded, is(notNullValue()));
         assertThat(loaded.getId(), is(equalTo("pipeline-id-one")));
-        assertThat(loaded.getConfigAsMap(), is(equalTo(EXPECTED_PIPELINE_ID_ONE_CONFIG_MAP)));
+        assertThat(loaded.getConfig(), is(equalTo(EXPECTED_PIPELINE_ID_ONE_CONFIG_MAP)));
     }
 
     @Test
@@ -74,7 +74,7 @@ class PipelineConfigurationFactoryTest {
 
         assertThat(loaded.get(0), is(notNullValue()));
         assertThat(loaded.get(0).getId(), is(equalTo("pipeline-id-one")));
-        assertThat(loaded.get(0).getConfigAsMap(), is(equalTo(EXPECTED_PIPELINE_ID_ONE_CONFIG_MAP)));
+        assertThat(loaded.get(0).getConfig(), is(equalTo(EXPECTED_PIPELINE_ID_ONE_CONFIG_MAP)));
     }
 
     @Test
@@ -86,12 +86,12 @@ class PipelineConfigurationFactoryTest {
 
         assertThat(loaded.get(0), is(notNullValue()));
         assertThat(loaded.get(0).getId(), is(equalTo("pipeline-id-one")));
-        assertThat(loaded.get(0).getConfigAsMap(), is(equalTo(EXPECTED_PIPELINE_ID_ONE_CONFIG_MAP)));
+        assertThat(loaded.get(0).getConfig(), is(equalTo(EXPECTED_PIPELINE_ID_ONE_CONFIG_MAP)));
 
 
         assertThat(loaded.get(1), is(notNullValue()));
         assertThat(loaded.get(1).getId(), is(equalTo("pipeline-id-two")));
-        assertThat(loaded.get(1).getConfigAsMap(), is(equalTo(EXPECTED_PIPELINE_ID_TWO_CONFIG_MAP)));
+        assertThat(loaded.get(1).getConfig(), is(equalTo(EXPECTED_PIPELINE_ID_TWO_CONFIG_MAP)));
     }
 
     @Test
@@ -109,7 +109,7 @@ class PipelineConfigurationFactoryTest {
         final PipelineConfiguration loaded = PipelineConfigurationFactory.getInstance().parseConfigOnly("bananas" , json);
         assertThat(loaded, is(notNullValue()));
         assertThat(loaded.getId(), is(equalTo("bananas")));
-        assertThat(loaded.getConfigAsMap(), is(equalTo(EXPECTED_PIPELINE_ID_ONE_CONFIG_MAP)));
+        assertThat(loaded.getConfig(), is(equalTo(EXPECTED_PIPELINE_ID_ONE_CONFIG_MAP)));
     }
 
     String elasticsearchApiFormattedJson(final String name) throws IOException {


### PR DESCRIPTION
### What does this PR change?
Recently ES `PipelineConfiguration` class renamed its `getConfigAsMap()` to `getConfig()`. This caused plugin build and this PR applies the ES change. 

- Closes #189 

### Ci failure notes
This change will fail on the CI steps which target ES `8.x` (including snapshot), because `PipelineConfiguration->getConfig(boolean)` interface is _only_ available in ES main.