### PR TITLE
Set header indicating product origin

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/ElasticsearchRestClientBuilder.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/ElasticsearchRestClientBuilder.java
@@ -461,6 +461,10 @@ public class ElasticsearchRestClientBuilder {
                 final HttpRequestInterceptor interceptor = new EAVHttpRequestInterceptor(elasticApiVersionHeader);
                 HttpClientConfigurator.forAddInterceptorFirst(interceptor).configure(httpClientBuilder);
             }
+            // Set header indicating internal use
+            final BasicHeader productOriginHeader = new BasicHeader("x-elastic-product-origin", "logstash-filter-elastic_integration");
+            final HttpRequestInterceptor productOriginHeaderInterceptor = new EAVHttpRequestInterceptor(productOriginHeader);
+            HttpClientConfigurator.forAddInterceptorFirst(productOriginHeaderInterceptor).configure(httpClientBuilder);
         }
     }
 }


### PR DESCRIPTION
This commit updates the elasticsearch client to set a header indicating which product component is using the API.

Closes https://github.com/elastic/logstash-filter-elastic_integration/issues/183