### PR TITLE
A matrix to define compatibility across stack versions, where CI job generator leverages

### DIFF
--- a/.buildkite/pull-request-test-matrix.yml
+++ b/.buildkite/pull-request-test-matrix.yml
@@ -1,0 +1,22 @@
+# a map defines the compatibility between versions
+# some of them might not exist,
+#  and they do not break CI which jobs generator validates the release/snapshot when generating the CI steps
+8.x:
+  releases:
+    - 8.previous
+    - 8.current
+  snapshots:
+    - 8.previous
+    - 8.current
+    - 8.next
+    - 8.future
+main:
+  releases:
+    - 9.previous
+    - 9.current
+  snapshots:
+    - 9.previous
+    - 9.current
+    - 9.next
+    - 9.future
+    - main

--- a/.buildkite/pull-request-test-matrix.yml
+++ b/.buildkite/pull-request-test-matrix.yml
@@ -15,6 +15,7 @@ main:
     - 9.previous
     - 9.current
   snapshots:
+    - 8.future
     - 9.previous
     - 9.current
     - 9.next


### PR DESCRIPTION
### Description
When we raise PR, we need to test the plugin changes against its base branch across multiple stacks to make sure we do not break the plugin. This PR introduces the pull-request matrix where all `8.series` branches will align on `8.x` map and `main` with `main` accordingly. The matrix entry for `main` covers the upgrade path where `8.last.last` (will be maintained through release cycle) will be always tested against next major, `9.x/main` for now.

[Dynamic job generator PR](https://github.com/elastic/logstash-filter-elastic_integration/pull/199) applies this change with `YAML()` tool which easifies out life.
```
    matrix_map = call_url_with_retry(MATRIX_MAP)
    matrix_map_yaml = YAML().load(matrix_map.text)
    print(f"matrix_map: {matrix_map_yaml['8.x']}")
```