### PR TITLE
Generate noop CI step if next (is only available during the FF) is N.A

### DIFF
--- a/.buildkite/scripts/build-pipeline/generate-steps.py
+++ b/.buildkite/scripts/build-pipeline/generate-steps.py
@@ -42,7 +42,7 @@ def generate_steps_for_scheduler(versions) -> list:
     steps: list = []
     snapshots = versions["snapshots"]
     for snapshot_version in snapshots:
-        if snapshots[snapshot_version] is None or snapshots[snapshot_version].startswith("7."):
+        if snapshots.get(snapshot_version,"").startswith("7."):
             continue
         full_stack_version = snapshots[snapshot_version]
         version_parts = snapshots[snapshot_version].split(".")

--- a/.buildkite/scripts/build-pipeline/generate-steps.py
+++ b/.buildkite/scripts/build-pipeline/generate-steps.py
@@ -42,7 +42,7 @@ def generate_steps_for_scheduler(versions) -> list:
     steps: list = []
     snapshots = versions["snapshots"]
     for snapshot_version in snapshots:
-        if snapshots[snapshot_version].startswith("7."):
+        if snapshots[snapshot_version] is None or snapshots[snapshot_version].startswith("7."):
             continue
         full_stack_version = snapshots[snapshot_version]
         version_parts = snapshots[snapshot_version].split(".")

--- a/.buildkite/scripts/e2e-pipeline/generate-steps.py
+++ b/.buildkite/scripts/e2e-pipeline/generate-steps.py
@@ -38,7 +38,7 @@ def generate_steps_for_scheduler(versions) -> list:
     steps: list = []
     snapshots = versions["snapshots"]
     for snapshot_version in snapshots:
-        if snapshots[snapshot_version].startswith("7."):
+        if snapshots[snapshot_version] is None or snapshots[snapshot_version].startswith("7."):
             continue
         full_stack_version = snapshots[snapshot_version]
         version_parts = snapshots[snapshot_version].split(".")

--- a/.buildkite/scripts/e2e-pipeline/generate-steps.py
+++ b/.buildkite/scripts/e2e-pipeline/generate-steps.py
@@ -38,7 +38,7 @@ def generate_steps_for_scheduler(versions) -> list:
     steps: list = []
     snapshots = versions["snapshots"]
     for snapshot_version in snapshots:
-        if snapshots[snapshot_version] is None or snapshots[snapshot_version].startswith("7."):
+        if snapshots.get(snapshot_version,"").startswith("7."):
             continue
         full_stack_version = snapshots[snapshot_version]
         version_parts = snapshots[snapshot_version].split(".")


### PR DESCRIPTION
### Description
Oops, snapshot next stack version can be null since it is only available during the FF. I covered it in the pull-request pipeline and forgot noop placeholder in build/E2E pipeline where this PR covers.

### CI state
- we don't need to wait or doesn't relate to pull-request CI changes