### PR TITLE
Don't trigger CI when pushing branches

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -58,7 +58,7 @@ spec:
       provider_settings:
         build_pull_requests: true
         build_pull_request_forks: false
-        build_branches: true
+        build_branches: false
         build_tags: false
         filter_enabled: true
         filter_condition: >-


### PR DESCRIPTION
This commit stops triggering BK from triggering CI when branches get pushed. We rely on CI for PRs, instead, which is handled by the BK PR Bot.
