### PR TITLE
Add an E2E step to scan unsupported processors.

### DIFF
--- a/.buildkite/scripts/e2e-pipeline/requirements.txt
+++ b/.buildkite/scripts/e2e-pipeline/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.31.0
 docker==7.0.0
+ruamel.yaml==0.18.10


### PR DESCRIPTION
### Description
We don't have yet the integrations with `elastic_integration` unsupported processors. This PR adds a script to search processors the plugin cannot run.

E2E run: https://buildkite.com/elastic/logstash-filter-elastic-integration-e2e/builds/195