### PR TITLE
mergify: support backports automation with labels

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -12,7 +12,7 @@
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "skip_target_branches": [],
-      "skip_ci_on_only_changed": ["^docs/"],
+      "skip_ci_on_only_changed": ["^.github/", "^docs/", "^.mergify.yml", "^.pre-commit-config.yaml"],
       "always_require_ci_on_changed": [],
       "skip_ci_labels": []
     }

--- a/.github/workflows/mergify-labels-copier.yml
+++ b/.github/workflows/mergify-labels-copier.yml
@@ -1,0 +1,23 @@
+name: mergify backport labels copier
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  contents: read
+
+jobs:
+  mergify-backport-labels-copier:
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'mergify/bp/')
+    permissions:
+      # Add GH labels
+      pull-requests: write
+      # See https://github.com/cli/cli/issues/6274
+      repository-projects: read
+    steps:
+      - uses: elastic/oblt-actions/mergify/labels-copier@v1
+        with:
+          excluded-labels-regex: "^backport-*"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,18 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 8.*
+      - 9.*
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/oblt-actions/pre-commit@v1

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,114 @@
+pull_request_rules:
+  - name: ask to resolve conflict
+    conditions:
+      - conflict
+    actions:
+      comment:
+        message: |
+          This pull request is now in conflicts. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
+          ```
+          git fetch upstream
+          git checkout -b {{head}} upstream/{{head}}
+          git merge upstream/{{base}}
+          git push upstream {{head}}
+          ```
+
+  - name: notify the backport policy
+    conditions:
+      - -label~=^backport
+      - base=main
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `backport-8./d` is the label to automatically backport to the `8./d` branch. `/d` is the digit.
+          * `backport-8.x` is the label to automatically backport to the `8.x` branch.
+
+  - name: add backport-8.x for the all the PRs targeting main if no skipped or assigned already
+    conditions:
+      - -label~=^(backport-skip|backport-8.x)$
+      - base=main
+    actions:
+      comment:
+        message: |
+          `backport-8.x` has been added to help with the transition to the new branch `8.x`.
+          If you don't need it please use `backport-skip` label.
+      label:
+        add:
+          - backport-8.x
+
+  - name: remove backport-skip label
+    conditions:
+      - label~=^backport-\d
+    actions:
+      label:
+        remove:
+          - backport-skip
+
+  - name: remove backport-8.x label if backport-skip is present
+    conditions:
+      - label~=^backport-skip
+    actions:
+      label:
+        remove:
+          - backport-8.x
+
+  - name: notify the backport has not been merged yet
+    conditions:
+      - -merged
+      - -closed
+      - author=mergify[bot]
+      - "#check-success>0"
+      - schedule=Mon-Mon 06:00-10:00[Europe/Paris]
+    actions:
+      comment:
+        message: |
+          This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏
+
+  - name: backport patches to 8.x branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.x
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.x"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+
+  - name: backport patches to 8.16 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.16
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.16"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+
+  - name: backport patches to 8.17 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.17
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.17"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -159,7 +159,6 @@ pull_request_rules:
           - "8.17"
           - "8.16"
           - "8.x"
-          - "7.17"
         labels:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,19 +1,4 @@
 pull_request_rules:
-  - name: ask to resolve conflict
-    conditions:
-      - conflict
-    actions:
-      comment:
-        message: |
-          This pull request is now in conflicts. Could you fix it @{{author}}? 🙏
-          To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
-          ```
-          git fetch upstream
-          git checkout -b {{head}} upstream/{{head}}
-          git merge upstream/{{base}}
-          git push upstream {{head}}
-          ```
-
   - name: notify the backport policy
     conditions:
       - -label~=^backport
@@ -26,19 +11,7 @@ pull_request_rules:
           branches, such as:
           * `backport-8./d` is the label to automatically backport to the `8./d` branch. `/d` is the digit.
           * `backport-8.x` is the label to automatically backport to the `8.x` branch.
-
-  - name: add backport-8.x for the all the PRs targeting main if no skipped or assigned already
-    conditions:
-      - -label~=^(backport-skip|backport-8.x)$
-      - base=main
-    actions:
-      comment:
-        message: |
-          `backport-8.x` has been added to help with the transition to the new branch `8.x`.
-          If you don't need it please use `backport-skip` label.
-      label:
-        add:
-          - backport-8.x
+          * If no backport is necessary, please add the `backport-skip` label
 
   - name: remove backport-skip label
     conditions:
@@ -47,14 +20,6 @@ pull_request_rules:
       label:
         remove:
           - backport-skip
-
-  - name: remove backport-8.x label if backport-skip is present
-    conditions:
-      - label~=^backport-skip
-    actions:
-      label:
-        remove:
-          - backport-8.x
 
   - name: notify the backport has not been merged yet
     conditions:
@@ -109,6 +74,92 @@ pull_request_rules:
           - "{{ author }}"
         branches:
           - "8.17"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+
+  - name: backport patches to 8.18 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.18
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.18"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+
+  - name: backport patches to 9.0 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-9.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "9.0"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+
+  - name: backport patches to all active minor branches for the 8 major.
+    conditions:
+      - merged
+      - label=backport-active-8
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing minor branch reached EOL.
+        branches:
+          - "8.x"
+          - "8.18"
+          - "8.17"
+          - "8.16"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+
+  - name: backport patches to all active minor branches for the 9 major.
+    conditions:
+      - merged
+      - label=backport-active-9
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing minor branch reached EOL.
+        branches:
+          - "9.0"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+
+  - name: backport patches to all active branches
+    conditions:
+      - merged
+      - label=backport-active-all
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        # NOTE: this list needs to be changed when a new minor branch is created
+        #       or an existing release branch reached EOL.
+        branches:
+          - "9.0"
+          - "8.18"
+          - "8.17"
+          - "8.16"
+          - "8.x"
+          - "7.17"
         labels:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+    -   id: check-executables-have-shebangs
+    -   id: check-shebang-scripts-are-executable
+    -   id: check-merge-conflict
+        args: ['--assume-in-merge']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,5 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
-    -   id: check-executables-have-shebangs
-    -   id: check-shebang-scripts-are-executable
     -   id: check-merge-conflict
         args: ['--assume-in-merge']


### PR DESCRIPTION
## What does this PR do?

* Enable https://docs.mergify.com/workflow for:
  - Creating backports automatically using GitHub backport labels when the original PR gets merged.
  - Notify when backports are stalled.
  - Notify the backports policy
  - Create PRs even with conflicts.
* Enable copy GitHub labels from the original PR to the backported PRs. `Mergify` does not support this feature out of the box, see https://github.com/elastic/apm-server/pull/15190
* Enable merge conflict detection. See https://github.com/elastic/apm-server/pull/15319

## Why is it important/What is the impact to the user?

Use the same backport mechanism as done in some other projects. While still support for the former approach.

### Tasks

- [x] Wait for Mergify to be installed
- [x] Create GitHub labels

### Follow-ups

- Delete https://github.com/elastic/logstash-filter-elastic_integration/blob/main/.github/workflows/pr_backporter.yml

## Related issues

Relates https://github.com/elastic/logstash/issues/16933
