### PR TITLE
Simplify running E2E test script on local.

### DIFF
--- a/.buildkite/scripts/e2e-pipeline/README.md
+++ b/.buildkite/scripts/e2e-pipeline/README.md
@@ -41,11 +41,14 @@ Make sure you have python installed on you local
 pip install -r .buildkite/scripts/e2e-pipeline/requirements.txt
 ```
 
-### Run
+### Run on local
 Run the following command from the repo dir:
 ```bash
-python3 .buildkite/scripts/e2e-pipeline/main.py
+python3 .buildkite/scripts/e2e-pipeline/main.py --skip-setup=true --integrations='apache','nginx'
 ```
+
+This will run entire ELK docker containers.
+Remove `--skip-setup` or use `--skip-setup=true` if you are running the script for the first time, where it needs to set up elastic-package and integrations. 
 
 ## Troubleshooting
 - The project retries on some operations to overcome timeout issues, uses [`retry` tool](https://formulae.brew.sh/formula/retry). If you get `retry` undefined error, make sure to install it.

--- a/.buildkite/scripts/e2e-pipeline/bootstrap.py
+++ b/.buildkite/scripts/e2e-pipeline/bootstrap.py
@@ -190,7 +190,7 @@ class Bootstrap:
         """
         Downloads elastic-package, creates a profile and runs ELK, Fleet, ERP and elastic-agent
         """
-        if skip_setup is False:
+        if not skip_setup:
             self.__download_elastic_package()
             self.__make_elastic_package_global()
             self.__clone_integrations_repo()

--- a/.buildkite/scripts/e2e-pipeline/bootstrap.py
+++ b/.buildkite/scripts/e2e-pipeline/bootstrap.py
@@ -14,6 +14,7 @@ import ruamel.yaml
 
 YAML = ruamel.yaml.YAML()
 
+
 class Bootstrap:
     ELASTIC_PACKAGE_DISTRO_URL = "https://api.github.com/repos/elastic/elastic-package/releases/latest"
     LOGSTASH_CONTAINER_NAME = "elastic-package-stack-e2e-logstash-1"
@@ -87,7 +88,7 @@ class Bootstrap:
         curr_dir = os.getcwd()
         pipeline_definition_file_path = "integrations/packages/**/data_stream/**/elasticsearch/ingest_pipeline/*.yml"
         files = glob.glob(os.path.join(curr_dir, pipeline_definition_file_path))
-        unsupported_processors: dict[list] = {}   # {processor_type: list<file>}
+        unsupported_processors: dict[list] = {}  # {processor_type: list<file>}
 
         for file in files:
             try:
@@ -185,15 +186,16 @@ class Bootstrap:
         util.run_or_raise_error(["elastic-package", "stack", "down"],
                                 "Error occurred while stopping stacks with elastic-package. Check logs for details.")
 
-    def run_elastic_stack(self) -> None:
+    def run_elastic_stack(self, skip_setup=False) -> None:
         """
         Downloads elastic-package, creates a profile and runs ELK, Fleet, ERP and elastic-agent
         """
-        self.__download_elastic_package()
-        self.__make_elastic_package_global()
-        self.__clone_integrations_repo()
-        self.__scan_for_unsupported_processors()
-        self.__setup_elastic_package_profile()
+        if skip_setup is False:
+            self.__download_elastic_package()
+            self.__make_elastic_package_global()
+            self.__clone_integrations_repo()
+            self.__scan_for_unsupported_processors()
+            self.__setup_elastic_package_profile()
         self.__spin_stack()
         self.__install_plugin()
         self.__reload_container()

--- a/.buildkite/scripts/e2e-pipeline/main.py
+++ b/.buildkite/scripts/e2e-pipeline/main.py
@@ -64,7 +64,7 @@ def main(skip_setup=False, integrations=[]):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--skip-setup, 'action='store_true')
+    parser.add_argument('--skip-setup, 'action='store_false')
     parser.add_argument('--integrations')
     args = parser.parse_args()
 

--- a/.buildkite/scripts/e2e-pipeline/main.py
+++ b/.buildkite/scripts/e2e-pipeline/main.py
@@ -41,7 +41,7 @@ def main(skip_setup=False, integrations=[]):
     with BootstrapContextManager(skip_setup) as bootstrap:
         working_dir = os.getcwd()
         test_plugin = PluginTest()
-        packages = integrations if len(integrations) > 0 else INTEGRATION_PACKAGES_TO_TEST
+        packages = integrations or INTEGRATION_PACKAGES_TO_TEST
         for package in packages:
             try:
                 os.chdir(f"{working_dir}/integrations/packages/{package}")
@@ -64,12 +64,12 @@ def main(skip_setup=False, integrations=[]):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--skip-setup')
+    parser.add_argument('--skip-setup, 'action='store_true')
     parser.add_argument('--integrations')
     args = parser.parse_args()
 
-    skip_setup = args.skip_setup == 'true' if args.skip_setup is not None else False
-    integrations = args.integrations.split(',') if args.integrations is not None else []
+    skip_setup = args.skip_setup
+    integrations = args.integrations.split(',') if args.integrations else []
 
     print(f"Running with --skip-setup:{skip_setup}, --integrations:{integrations}")
     main(skip_setup, integrations)


### PR DESCRIPTION
Simplifies running E2E test script on local by introducing skip set up and integrations to test options.
When first running E2E tests, setup is required. For the next steps setup can be skipped.