### PR TITLE
Sets default False value to skip-setup flag.

### DIFF
--- a/.buildkite/scripts/e2e-pipeline/main.py
+++ b/.buildkite/scripts/e2e-pipeline/main.py
@@ -64,7 +64,7 @@ def main(skip_setup=False, integrations=[]):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--skip-setup', action='store_false')
+    parser.add_argument('--skip-setup', action='store_true') # store_true adds default False if argument is unavailable.
     parser.add_argument('--integrations')
     args = parser.parse_args()
 


### PR DESCRIPTION
Our understanding of `'--skip-setup' action='store_true'` seems incorrect that E2E CIs ([example](https://buildkite.com/elastic/logstash-filter-elastic-integration-e2e/builds/204#0195c00d-2767-4bb1-bb45-a0c41d7c3368/60-169)) running with `--skip-setup=True`.
When I take a look at the `store_true`, it seems it automatically _stores_  the default `False` value: https://hg.python.org/cpython/file/2.7/Lib/argparse.py#l861

Similar discussion can be seen here: https://stackoverflow.com/a/8203679