### PR TITLE
mergify: support 8.19 and remove support 8.x

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -24,7 +24,6 @@ pull_request_rules:
           To fixup this pull request, you need to add the backport labels for the needed
           branches, such as:
           * `backport-8./d` is the label to automatically backport to the `8./d` branch. `/d` is the digit.
-          * `backport-8.x` is the label to automatically backport to the `8.x` branch.
           * If no backport is necessary, please add the `backport-skip` label
 
   - name: remove backport-skip label
@@ -46,21 +45,6 @@ pull_request_rules:
       comment:
         message: |
           This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏
-
-  - name: backport patches to 8.x branch
-    conditions:
-      - merged
-      - base=main
-      - label=backport-8.x
-    actions:
-      backport:
-        assignees:
-          - "{{ author }}"
-        branches:
-          - "8.x"
-        labels:
-          - "backport"
-        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
 
   - name: backport patches to 8.16 branch
     conditions:
@@ -106,6 +90,16 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+
+  - name: backport patches to 8.19 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.19
+    actions:
+      backport:
+        branches:
+          - "8.19"
 
   - name: backport patches to 9.0 branch
     conditions:


### PR DESCRIPTION
8.x branch will be renamed to `8.19`.