### PR TITLE
Display logs with gradle task logs if ES build fails.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -243,7 +243,16 @@ task buildElasticsearchLocalDistro(dependsOn: unzipDownloadedElasticsearchSource
     ignoreExitValue true // handled in doLast
     doLast {
         def exitValue = executionResult.get().exitValue
-        assert exitValue == 0 : "Elasticsearch build failed; logs available in ${logFile.path}"
+        if (exitValue != 0) {
+            if (logFile.exists()) {
+                println "\n===== Elasticsearch Build Log ====="
+                println logFile.text
+                println "===== End of Build Log =====\n"
+            } else {
+                "Elasticsearch build failed and ${logFile.path} log does not exist"
+            }
+            throw new GradleException("Elasticsearch build failed, see the logs for details.")
+        }
         assert ext.localDistroResult.isPresent() : "Elasticsearch did not produce exactly one localdistro build"
     }
 }


### PR DESCRIPTION
Updates `buildElasticsearchLocalDistro` task to display error logs when ES build fails.