### PR TITLE
Sync up with Elasticsearch main on GeoIP changes.

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/IpDatabaseProvider.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/geoip/IpDatabaseProvider.java
@@ -8,6 +8,7 @@ package co.elastic.logstash.filters.elasticintegration.geoip;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.ingest.geoip.IpDatabase;
 
@@ -33,13 +34,13 @@ public class IpDatabaseProvider implements org.elasticsearch.ingest.geoip.IpData
     }
 
     @Override
-    public Boolean isValid(String databaseIdentifierFileName) {
+    public Boolean isValid(ProjectId projectId, String databaseIdentifierFileName) {
         final IpDatabaseHolder holder = getDatabaseHolder(databaseIdentifierFileName);
         return Objects.nonNull(holder) && holder.isValid();
     }
 
     @Override
-    public IpDatabase getDatabase(String databaseIdentifierFileName) {
+    public IpDatabase getDatabase(ProjectId projectId, String databaseIdentifierFileName) {
         final IpDatabaseHolder holder = getDatabaseHolder(databaseIdentifierFileName);
         if (Objects.isNull(holder)) {
             return null;

--- a/src/test/java/co/elastic/logstash/filters/elasticintegration/geoip/IpDatabaseProviderTest.java
+++ b/src/test/java/co/elastic/logstash/filters/elasticintegration/geoip/IpDatabaseProviderTest.java
@@ -9,6 +9,7 @@ package co.elastic.logstash.filters.elasticintegration.geoip;
 
 import co.elastic.logstash.filters.elasticintegration.util.IngestDocumentUtil;
 import co.elastic.logstash.filters.elasticintegration.util.ResourcesUtil;
+import org.elasticsearch.cluster.metadata.ProjectId;
 import org.elasticsearch.ingest.IngestDocument;
 import org.elasticsearch.ingest.Processor;
 import org.elasticsearch.ingest.geoip.GeoIpProcessor;
@@ -35,16 +36,17 @@ class IpDatabaseProviderTest {
 
     @Test
     void loadTestVendoredDatabases() throws Exception {
+
         withVendoredGeoIpDatabaseProvider(geoIpDatabaseProvider -> {
             assertAll("Loaded databases all report valid",
-                    () -> assertThat(geoIpDatabaseProvider.isValid("GeoLite2-ASN.mmdb"), is(true)),
-                    () -> assertThat(geoIpDatabaseProvider.isValid("GeoLite2-City.mmdb"), is(true)),
-                    () -> assertThat(geoIpDatabaseProvider.isValid("GeoLite2-Country.mmdb"), is(true)));
+                    () -> assertThat(geoIpDatabaseProvider.isValid(ProjectId.DEFAULT, "GeoLite2-ASN.mmdb"), is(true)),
+                    () -> assertThat(geoIpDatabaseProvider.isValid(ProjectId.DEFAULT, "GeoLite2-City.mmdb"), is(true)),
+                    () -> assertThat(geoIpDatabaseProvider.isValid(ProjectId.DEFAULT, "GeoLite2-Country.mmdb"), is(true)));
 
             assertAll("Non-loaded databases all report invalid",
-                    () -> assertThat(geoIpDatabaseProvider.isValid("GeoLite2-Global.mmdb"), is(false)),
-                    () -> assertThat(geoIpDatabaseProvider.isValid("Bananas.mmdb"), is(false)),
-                    () -> assertThat(geoIpDatabaseProvider.isValid("Intergalactic.mmdb"), is(false)));
+                    () -> assertThat(geoIpDatabaseProvider.isValid(ProjectId.DEFAULT, "GeoLite2-Global.mmdb"), is(false)),
+                    () -> assertThat(geoIpDatabaseProvider.isValid(ProjectId.DEFAULT, "Bananas.mmdb"), is(false)),
+                    () -> assertThat(geoIpDatabaseProvider.isValid(ProjectId.DEFAULT, "Intergalactic.mmdb"), is(false)));
         });
     }
 
@@ -131,7 +133,7 @@ class IpDatabaseProviderTest {
     }
 
     static void withGeoipProcessor(final IpDatabaseProvider geoIpDatabaseProvider, Map<String, Object> config, ExceptionalConsumer<Processor> geoIpProcessorConsumer) throws Exception {
-        Processor processor = new GeoIpProcessor.Factory("geoip", geoIpDatabaseProvider).create(Map.of(), null, null, config);
+        Processor processor = new GeoIpProcessor.Factory("geoip", geoIpDatabaseProvider).create(Map.of(), null, null, config, null);
         geoIpProcessorConsumer.accept(processor);
     }
 


### PR DESCRIPTION
### Description

GeoIp interface changes: `IpDatabaseProvider#isValid` and `IpDatabaseProvider#getDatabase` methods have now `projectId` additional params.

- Needs to backport to 9.1 branch

### Test
- Java test: run locally for now but will be addressed with https://github.com/elastic/logstash-filter-elastic_integration/pull/306

```
╰─➤  ./gradlew test

> Task :downloadElasticsearchSourceZip
Download https://github.com/elastic/elasticsearch/archive/refs/heads/main.zip

> Task :test

co.elastic.logstash.filters.elasticintegration.DatastreamEventToIndexNameResolverTest

  Test eventWithDatastreamMissingNamespace() PASSED (1.1s)
  Test eventWithDatastream() PASSED
  Test eventWithMalformedDatastream() PASSED
  Test eventWithDatastreamMissingType() PASSED
  Test eventWithDatastreamMissingDataset() PASSED
  Test eventWithoutDatastream() PASSED

Gradle Test Executor 3 STANDARD_ERROR
    SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
    SLF4J: Defaulting to no-operation (NOP) logger implementation
    SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

co.elastic.logstash.filters.elasticintegration.ElasticsearchIndexNameToPipelineNameResolverTest

  Test indexTemplateWithDefaultPipeline() PASSED
  Test indexWithEscapableCharacters() PASSED
  Test indexTemplateWithImplicitNoneDefaultPipeline() PASSED

ElasticsearchIndexNameToPipelineNameResolverTest > insufficientPermissionsToUsSimulateAPI() STANDARD_OUT
    error determining pipeline for datastream `logs-some_pipeline-default` [(org.elasticsearch.client.ResponseException: method [POST], host [http://127.0.0.1:57455], URI [/_index_template/_simulate_index/logs-some_pipeline-default], status line [HTTP/1.1 403 Forbidden]
    )]

ElasticsearchIndexNameToPipelineNameResolverTest > insufficientPermissionsToUsSimulateAPI() STANDARD_ERROR
    HANDLED: org.elasticsearch.client.ResponseException: method [POST], host [http://127.0.0.1:57455], URI [/_index_template/_simulate_index/logs-some_pipeline-default], status line [HTTP/1.1 403 Forbidden]

  Test insufficientPermissionsToUsSimulateAPI() PASSED
  Test indexTemplateWithExplicitNoneDefaultPipeline() PASSED
  Test indexWithoutTemplateSettings() PASSED

co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolverTest

  Test testLoadConfigurationExists() PASSED

ElasticsearchPipelineConfigurationResolverTest > testLoadConfigurationNotAuthorized() STANDARD_OUT
    failed to fetch pipeline: `who-am-i`
    org.elasticsearch.client.ResponseException: method [GET], host [http://127.0.0.1:57462], URI [/_ingest/pipeline/who-am-i], status line [HTTP/1.1 403 Forbidden]

        at org.elasticsearch.client.RestClient.convertResponse(RestClient.java:351) ~[elasticsearch-rest-client-8.18.0.jar:8.18.0]
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:317) ~[elasticsearch-rest-client-8.18.0.jar:8.18.0]
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:292) ~[elasticsearch-rest-client-8.18.0.jar:8.18.0]
        at co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolver.resolveSafely(ElasticsearchPipelineConfigurationResolver.java:44) ~[main/:?]
        at co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolver.resolveSafely(ElasticsearchPipelineConfigurationResolver.java:26) ~[main/:?]
        at co.elastic.logstash.filters.elasticintegration.resolver.AbstractSimpleResolver.resolve(AbstractSimpleResolver.java:32) ~[main/:?]
        at co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolverTest.lambda$testLoadConfigurationNotAuthorized$5(ElasticsearchPipelineConfigurationResolverTest.java:106) ~[test/:?]
        at co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolverTest.lambda$withPipelineConfigurationResolver$6(ElasticsearchPipelineConfigurationResolverTest.java:124) ~[test/:?]
        at co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolverTest.withWiremockElasticsearch(ElasticsearchPipelineConfigurationResolverTest.java:118) ~[test/:?]
        at co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolverTest.withPipelineConfigurationResolver(ElasticsearchPipelineConfigurationResolverTest.java:123) ~[test/:?]
        at co.elastic.logstash.filters.elasticintegration.ElasticsearchPipelineConfigurationResolverTest.testLoadConfigurationNotAuthorized(ElasticsearchPipelineConfigurationResolverTest.java:101) ~[test/:?]
        at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
        at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:766) ~[junit-platform-commons-1.11.0.jar:1.11.0]
        at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$8(TestMethodTestDescriptor.java:217) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:213) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:138) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68) ~[junit-jupiter-engine-5.11.0.jar:5.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at java.util.ArrayList.forEach(ArrayList.java:1596) ~[?:?]
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at java.util.ArrayList.forEach(ArrayList.java:1596) ~[?:?]
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54) ~[junit-platform-engine-1.11.0.jar:1.11.0]
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107) ~[junit-platform-launcher-1.8.2.jar:1.8.2]
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88) ~[junit-platform-launcher-1.8.2.jar:1.8.2]
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54) ~[junit-platform-launcher-1.8.2.jar:1.8.2]
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67) ~[junit-platform-launcher-1.8.2.jar:1.8.2]
        at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52) ~[junit-platform-launcher-1.8.2.jar:1.8.2]
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114) ~[junit-platform-launcher-1.8.2.jar:1.8.2]
        at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86) ~[junit-platform-launcher-1.8.2.jar:1.8.2]
        at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86) ~[junit-platform-launcher-1.8.2.jar:1.8.2]
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.processAllTestClasses(JUnitPlatformTestClassProcessor.java:119) ~[?:?]
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$CollectAllTestClassesExecutor.access$000(JUnitPlatformTestClassProcessor.java:94) ~[?:?]
        at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor.stop(JUnitPlatformTestClassProcessor.java:89) ~[?:?]
        at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.stop(SuiteTestClassProcessor.java:62) ~[?:?]
        at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:580) ~[?:?]
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36) ~[?:?]
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24) ~[?:?]
        at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33) ~[?:?]
        at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94) ~[?:?]
        at jdk.proxy1.$Proxy2.stop(Unknown Source) ~[?:?]
        at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:193) ~[?:?]

OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended

> Task :test
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:129) ~[?:?]
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:100) ~[?:?]
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:60) ~[?:?]
        at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56) ~[?:?]
        at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:113) ~[?:?]
        at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:65) ~[?:?]
        at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69) ~[gradle-worker.jar:?]
        at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74) ~[gradle-worker.jar:?]
  Test testLoadConfigurationNotAuthorized() PASSED
  Test testLoadConfigurationNotFound() PASSED
  Test testLoadConfigurationPipelineWithSpecialCharacters() PASSED

co.elastic.logstash.filters.elasticintegration.ElasticsearchRestClientBuilderTest

  Test testForHostsFactoryEmptyURLs() PASSED
  Test testForHostsFactoryURLsWithoutPort() PASSED
  Test testElasticApiConfigAddsHeaders() PASSED
  Test testForCloudIdFactory() PASSED
  Test testForHostsFactoryURLsWithMismatchingProtocol() PASSED
  Test testForHostsFactoryURLsWithMismatchingPath() PASSED
  Test testForHostsFactorySingleURL() PASSED
  Test testForHostsFactoryMultipleURLs() PASSED

co.elastic.logstash.filters.elasticintegration.ElasticsearchRestClientWireMockTest$BareHttp

  Test testBasicConnectivity() PASSED
  Test testBasicConnectivityHttpsToHttpEndpoint() PASSED

co.elastic.logstash.filters.elasticintegration.ElasticsearchRestClientWireMockTest$MutualHttps

  Test testBasicConnectivityConfiguringKeystore() PASSED
  Test testBasicConnectivityWithoutConfiguringTrustFailure() PASSED
  Test testBasicConnectivityDisablingVerification() PASSED
  Test testBasicConnectivityConfiguringCertificateKeyPair() PASSED

co.elastic.logstash.filters.elasticintegration.ElasticsearchRestClientWireMockTest$RestClientWithApiKey

  Test testWithMismatchKeyInRequest() PASSED
  Test testWithNoApiKeyInRequest() PASSED
  Test testWithEncodedApiKey() PASSED
  Test testWithBase64ApiKey() PASSED

co.elastic.logstash.filters.elasticintegration.ElasticsearchRestClientWireMockTest$RestClientWithBasicAuth

  Test testPreemtiveBasicAuth() PASSED

co.elastic.logstash.filters.elasticintegration.ElasticsearchRestClientWireMockTest$SimpleHttps

  Test testBasicConnectivityConfiguringTruststore() PASSED
  Test testBasicConnectivityWithoutConfiguringTrustFailure() PASSED
  Test testBasicConnectivityConfiguringCertificateAuthorities() PASSED
  Test testBasicConnectivityDisablingVerification() PASSED

co.elastic.logstash.filters.elasticintegration.ElasticsearchRestClientWireMockTest$UserAgent

  Test testUserAgentHeader() PASSED

co.elastic.logstash.filters.elasticintegration.FieldValueEventToPipelineNameResolverTest

  Test testEventIncludesFieldWithNullValue() PASSED
  Test testEventIncludesFieldWithNonStringValue() PASSED
  Test testEventExcludesField() PASSED
  Test testEventIncludesFieldWithStringValue() PASSED

co.elastic.logstash.filters.elasticintegration.IngestDuplexMarshallerTest

  Test eventToIngestDocFieldWithNestedZonedDateTimeValue() PASSED
  Test ingestDocToEventModifiedMetadataVersion() PASSED
  Test ingestDocToEventIncludingReservedTagsFieldWithInvalidCoercibleShape() PASSED
  Test ingestDocToEventIncludingReservedAtVersionField() PASSED
  Test ingestDocToEventIncludingArrayType() PASSED
  Test ingestDocToEventIncludingReservedAtMetadataFieldWithAcceptableShape() PASSED
  Test eventToIngestDocFieldWithNestedTimestampValue() PASSED
  Test ingestDocToEventIncludingReservedTagsFieldWithListOfStringShape() PASSED
  Test ingestDocToEventAdditionalMetadata() PASSED
  Test ingestDocToEventModifiedAtTimestampInvalidStringValue() PASSED
  Test ingestDocToEventRemovedAtTimestamp() PASSED
  Test eventToIngestDocMissingRequiredTimestamp() PASSED
  Test ingestDocToEventModifiedAtTimestampStringValue() PASSED
  Test eventToIngestDoc() PASSED
  Test ingestDocToEventIncludingReservedTagsFieldWithStringShape() PASSED
  Test ingestDocToEventRemovedAtTimestampWithEventCreatedAt() PASSED
  Test ingestDocToEventIncludingReservedTagsFieldWithInvalidShape() PASSED
  Test ingestDocToEventIncludingReservedAtMetadataFieldWithInvalidShape() PASSED
  Test ingestDocToEventIncludingReservedAtTimestampField() PASSED
  Test eventToIngestDocMissingRequiredVersion() PASSED
  Test basicRoundTrip() PASSED
  Test ingestDocToEventModifiedAtTimestampZonedDateTimeValue() PASSED

co.elastic.logstash.filters.elasticintegration.LocalDirectoryPipelineConfigurationResolverTest

  Test resolveMissing() PASSED

LocalDirectoryPipelineConfigurationResolverTest > resolvePresentNonReadable() STANDARD_OUT
    File not readable: `/Users/mashhur/Dev/elastic/ls-plugins/logstash-filter-elastic_integration/build/resources/test/co/elastic/logstash/filters/elasticintegration/simple-mutate-pipelines/simple-mutate.json`
    File not readable: `/Users/mashhur/Dev/elastic/ls-plugins/logstash-filter-elastic_integration/build/resources/test/co/elastic/logstash/filters/elasticintegration/simple-mutate-pipelines/simple-mutate.json`
  Test resolvePresentNonReadable() PASSED

LocalDirectoryPipelineConfigurationResolverTest > resolvePresentWritable() STANDARD_OUT
    Refusing to load writable pipeline file: `/Users/mashhur/Dev/elastic/ls-plugins/logstash-filter-elastic_integration/build/resources/test/co/elastic/logstash/filters/elasticintegration/simple-mutate-pipelines/simple-mutate.json`
  Test resolvePresentWritable() PASSED
  Test resolvePresent() PASSED

co.elastic.logstash.filters.elasticintegration.PipelineConfigurationFactoryTest

  Test testParseNamedObjectsWithZeroPipelines() PASSED
  Test testParseNamedObjectWithZeroPipelines() PASSED
  Test testParseConfigOnly() PASSED
  Test testParseNamedObjectsWithOnePipeline() PASSED
  Test testParseNamedObjectsWithTwoPipelines() PASSED
  Test testParseNamedObjectWithTwoPipelines() PASSED
  Test testParseNamedObjectWithOnePipeline() PASSED

co.elastic.logstash.filters.elasticintegration.PreflightCheckTest

  Test checkCredentialsPrivilegesMissingReadPipeline() PASSED
  Test checkCredentialsPrivileges403Response() PASSED
  Test checkCredentialsPrivilegesConnectionError() PASSED
  Test checkServerlessVersionInfo() PASSED

PreflightCheckTest > checkLicense403() STANDARD_OUT
    Exception checking license: method [GET], host [http://127.0.0.1:57491], URI [/_license], status line [HTTP/1.1 403 Forbidden]

  Test checkLicense403() PASSED

PreflightCheckTest > checkLicenseConnectionError() STANDARD_OUT
    Exception checking license: Connection reset
  Test checkLicenseConnectionError() PASSED
  Test checkLicenseInvalid() PASSED
  Test checkCredentialsPrivilegesMissingMonitor() PASSED
  Test testElasticsearch401Response() PASSED
  Test checkLicenseExpired() PASSED
  Test checkCredentialsPrivilegesMissingManageIndexTemplates() PASSED
  Test checkLicenseActiveEnterprise() PASSED
  Test checkLicenseActiveBasic() PASSED
  Test checkCredentialsPrivilegesOK() PASSED
  Test testElasticsearchVersionInfo() PASSED

co.elastic.logstash.filters.elasticintegration.SmokeTest

  Test givenAFieldWithUserAgentStringTheCorrespondingProcessorIsAbleToParseIt() PASSED
  Test testSinglePipelineMutatingEvents() PASSED

SmokeTest > testMultiplePipelinesMutatingEvents() STANDARD_ERROR
    EXPLICIT-NONE: {@timestamp=2025-06-26T18:50:49.414580Z, toplevel=ok, @version=1, ignore_missing=true, id=explicit-none}//{ingest_pipeline=_none}
  Test testMultiplePipelinesMutatingEvents() PASSED
  Test testReroutePipelinesMutatingEvents() PASSED
  Test testPainlessAccessToIngestCommonProcessors() PASSED

co.elastic.logstash.filters.elasticintegration.SprintfTemplateEventToPipelineNameResolverTest

  Test sprintfFullyResolved() PASSED
  Test sprintfConstant() PASSED
  Test sprintfPartiallyResolved() PASSED

co.elastic.logstash.filters.elasticintegration.geoip.IpDatabaseProviderTest

  Test basicCityDBLookupCountryDetails() PASSED
  Test basicASNLookup() PASSED
  Test loadTestVendoredDatabases() PASSED
  Test basicCityDBLookupCityDetails() PASSED
  Test basicCountryDBLookupCountryDetails() PASSED

co.elastic.logstash.filters.elasticintegration.geoip.ManagedIpDatabaseHolderTest

  Test rejectTypeChangeOnReload() PASSED
  Test releaseOnReload() PASSED

co.elastic.logstash.filters.elasticintegration.resolver.ResolverTest

  Test testCacheableResolverTestImplementationBaseline() PASSED

co.elastic.logstash.filters.elasticintegration.resolver.SimpleResolverCacheTest

  Test resolve() PASSED

co.elastic.logstash.filters.elasticintegration.util.EventUtilTest

  Test testEnsureValidFieldReferenceBareword() PASSED
  Test testEnsureValidFieldReferenceTrailingIndexBrackets() PASSED
  Test testEnsureValidFieldReferenceNestedPathspec() PASSED
  Test testEnsureValidFieldReferenceTrailingBrackets() PASSED
  Test testEnsureValidFieldReferenceBroken() PASSED
  Test testEnsureValidFieldReferencePathspec() PASSED
  Test testSafeExtractValue() PASSED

co.elastic.logstash.filters.elasticintegration.util.ExceptionsTest

  Test messageFromUnwrappedIsIncludedInWrapped() PASSED

SUCCESS: Executed 117 tests in 10.8s


Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.7/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 2m 42s
13 actionable tasks: 8 executed, 5 up-to-date
```