### PR TITLE
Sync up with upstream ES main: apply project ID resolver to ScriptService.

### DIFF
--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
@@ -20,6 +20,7 @@ import co.elastic.logstash.filters.elasticintegration.util.PluginContext;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
 import org.elasticsearch.client.RestClient;
+import org.elasticsearch.cluster.project.DefaultProjectResolver;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;
@@ -318,7 +319,7 @@ public class EventProcessorBuilder {
         Map<String, ScriptEngine> engines = new HashMap<>();
         engines.put(PainlessScriptEngine.NAME, getPainlessScriptEngine(settings));
         engines.put(MustacheScriptEngine.NAME, new MustacheScriptEngine(settings));
-        return new ScriptService(settings, engines, ScriptModule.CORE_CONTEXTS, threadPool::absoluteTimeInMillis);
+        return new ScriptService(settings, engines, ScriptModule.CORE_CONTEXTS, threadPool::absoluteTimeInMillis, null);
     }
 
     /**

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
@@ -20,7 +20,6 @@ import co.elastic.logstash.filters.elasticintegration.util.PluginContext;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
 import org.elasticsearch.client.RestClient;
-import org.elasticsearch.cluster.project.DefaultProjectResolver;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.TimeValue;

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/EventProcessorBuilder.java
@@ -17,6 +17,7 @@ import co.elastic.logstash.filters.elasticintegration.resolver.SimpleResolverCac
 import co.elastic.logstash.filters.elasticintegration.resolver.ResolverCache;
 import co.elastic.logstash.filters.elasticintegration.util.Exceptions;
 import co.elastic.logstash.filters.elasticintegration.util.PluginContext;
+import co.elastic.logstash.filters.elasticintegration.util.PluginProjectResolver;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
 import org.elasticsearch.client.RestClient;
@@ -33,7 +34,6 @@ import org.elasticsearch.ingest.useragent.IngestUserAgentPlugin;
 import org.elasticsearch.painless.PainlessPlugin;
 import org.elasticsearch.painless.PainlessScriptEngine;
 import org.elasticsearch.painless.spi.PainlessExtension;
-import org.elasticsearch.painless.spi.Whitelist;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.script.IngestConditionalScript;
@@ -318,7 +318,13 @@ public class EventProcessorBuilder {
         Map<String, ScriptEngine> engines = new HashMap<>();
         engines.put(PainlessScriptEngine.NAME, getPainlessScriptEngine(settings));
         engines.put(MustacheScriptEngine.NAME, new MustacheScriptEngine(settings));
-        return new ScriptService(settings, engines, ScriptModule.CORE_CONTEXTS, threadPool::absoluteTimeInMillis, null);
+
+        return new ScriptService(
+                settings,
+                engines,
+                ScriptModule.CORE_CONTEXTS,
+                threadPool::absoluteTimeInMillis,
+                new PluginProjectResolver());
     }
 
     /**

--- a/src/main/java/co/elastic/logstash/filters/elasticintegration/util/PluginProjectResolver.java
+++ b/src/main/java/co/elastic/logstash/filters/elasticintegration/util/PluginProjectResolver.java
@@ -1,0 +1,21 @@
+package co.elastic.logstash.filters.elasticintegration.util;
+
+import org.elasticsearch.cluster.metadata.ProjectId;
+import org.elasticsearch.cluster.project.ProjectResolver;
+import org.elasticsearch.core.CheckedRunnable;
+
+public class PluginProjectResolver implements ProjectResolver {
+    @Override
+    public ProjectId getProjectId() {
+        return null;
+    }
+
+    @Override
+    public <E extends Exception> void executeOnProject(ProjectId projectId, CheckedRunnable<E> checkedRunnable) throws E {
+        if (projectId.equals(ProjectId.DEFAULT)) {
+            checkedRunnable.run();
+        } else {
+            throw new IllegalArgumentException("Cannot execute on a project other than [" + ProjectId.DEFAULT + "]");
+        }
+    }
+}


### PR DESCRIPTION
Sync up with upstream ES main: apply project ID resolver applied in logstash-bridge ScriptServiceBridge.

Applying as introduced in the logstash-bridge ScriptServiceBridge: https://github.com/elastic/elasticsearch/pull/130578/files#diff-f74baacde87eae5c09e26daf35f888065d68238e2593160179fb937c11d11327R73

~~Soon, this plugin will start using logstash-bridge instead direct `ScriptService` usage.~~ See [the observations](https://github.com/elastic/logstash-filter-elastic_integration/pull/357#discussion_r2255411211) that applying `null` breaks the plugin, so we may need to apply a logic to provide an actual project resolver.