### PR TITLE
Update buildkite script to look for new logstash releases location

### DIFF
--- a/.buildkite/scripts/build-pipeline/generate-steps.py
+++ b/.buildkite/scripts/build-pipeline/generate-steps.py
@@ -65,8 +65,7 @@ if __name__ == "__main__":
             "provider": "gcp",
             "machineType": "n2-standard-4",
             "imageProject": "elastic-images-prod",
-            "image": "family/platform-ingest-logstash-multi-jdk-ubuntu-2204",
-            "diskSizeGb": 120
+            "image": "family/platform-ingest-logstash-multi-jdk-ubuntu-2204"
         },
         "steps": []}
 

--- a/.buildkite/scripts/build-pipeline/generate-steps.py
+++ b/.buildkite/scripts/build-pipeline/generate-steps.py
@@ -63,8 +63,10 @@ if __name__ == "__main__":
     structure = {
         "agents": {
             "provider": "gcp",
-            "machineType": "n1-standard-4",
-            "image": "family/core-ubuntu-2204"
+            "machineType": "n2-standard-4",
+            "imageProject": "elastic-images-prod",
+            "image": "family/platform-ingest-logstash-multi-jdk-ubuntu-2204",
+            "diskSizeGb": 120
         },
         "steps": []}
 

--- a/.buildkite/scripts/build-pipeline/generate-steps.py
+++ b/.buildkite/scripts/build-pipeline/generate-steps.py
@@ -6,7 +6,7 @@ from requests.adapters import HTTPAdapter, Retry
 
 from ruamel.yaml import YAML
 
-RELEASES_URL = "https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash_releases.json"
+RELEASES_URL = "https://raw.githubusercontent.com/logstash-plugins/.ci/refs/heads/1.x/logstash-versions.yml"
 TEST_COMMAND: typing.final = ".buildkite/scripts/run_tests.sh"
 
 
@@ -69,7 +69,8 @@ if __name__ == "__main__":
         "steps": []}
 
     response = call_url_with_retry(RELEASES_URL)
-    versions_json: typing.final = response.json()
+    yaml = YAML(typ='safe')
+    versions_yaml: typing.final = yaml.load(response.text)
 
     # Use BUILDKITE_SOURCE to figure out PR merge or schedule.
     # If PR merge, no need to run builds on all branches, target branch will be good
@@ -79,8 +80,8 @@ if __name__ == "__main__":
     #       - manual kick off will be on PR or entire main branch, can be decided with BUILDKITE_BRANCH
     bk_source = os.getenv("BUILDKITE_SOURCE")
     bk_branch = os.getenv("BUILDKITE_BRANCH")
-    steps = generate_steps_for_scheduler(versions_json) if (bk_source == "schedule" or bk_branch == "main") \
-        else generate_steps_for_main_branch(versions_json)
+    steps = generate_steps_for_scheduler(versions_yaml) if (bk_source == "schedule" or bk_branch == "main") \
+        else generate_steps_for_main_branch(versions_yaml)
 
     group_desc = f"Build steps"
     key_desc = "build-steps"

--- a/.buildkite/scripts/e2e-pipeline/generate-steps.py
+++ b/.buildkite/scripts/e2e-pipeline/generate-steps.py
@@ -5,7 +5,7 @@ import typing
 from requests.adapters import HTTPAdapter, Retry
 from ruamel.yaml import YAML
 
-RELEASES_URL = "https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash_releases.json"
+RELEASES_URL = "https://raw.githubusercontent.com/logstash-plugins/.ci/refs/heads/1.x/logstash-versions.yml"
 TEST_COMMAND: typing.final = ".buildkite/scripts/run_e2e_tests.sh"
 
 
@@ -67,7 +67,8 @@ if __name__ == "__main__":
         "steps": []}
 
     response = call_url_with_retry(RELEASES_URL)
-    versions_json: typing.final = response.json()
+    yaml = YAML(typ='safe')
+    versions_yaml: typing.final = yaml.load(response.text)
 
     # Use BUILDKITE_SOURCE to figure out PR merge or schedule.
     # If PR merge, no need to run builds on all branches, target branch will be good
@@ -77,8 +78,8 @@ if __name__ == "__main__":
     #       - manual kick off will be on PR or entire main branch, can be decided with BUILDKITE_BRANCH
     bk_source = os.getenv("BUILDKITE_SOURCE")
     bk_branch = os.getenv("BUILDKITE_BRANCH")
-    steps = generate_steps_for_scheduler(versions_json) if (bk_source == "schedule" or bk_branch == "main") \
-        else generate_steps_for_main_branch(versions_json)
+    steps = generate_steps_for_scheduler(versions_yaml) if (bk_source == "schedule" or bk_branch == "main") \
+        else generate_steps_for_main_branch(versions_yaml)
 
     group_desc = f"E2E steps"
     key_desc = "e2e-steps"

--- a/.buildkite/scripts/pull-request-pipeline/generate-steps.py
+++ b/.buildkite/scripts/pull-request-pipeline/generate-steps.py
@@ -63,8 +63,7 @@ if __name__ == "__main__":
             "provider": "gcp",
             "machineType": "n2-standard-4",
             "imageProject": "elastic-images-prod",
-            "image": "family/platform-ingest-logstash-multi-jdk-ubuntu-2204",
-            "diskSizeGb": 120
+            "image": "family/platform-ingest-logstash-multi-jdk-ubuntu-2204"
         },
         "steps": []}
 

--- a/.buildkite/scripts/pull-request-pipeline/generate-steps.py
+++ b/.buildkite/scripts/pull-request-pipeline/generate-steps.py
@@ -6,7 +6,7 @@ from requests.adapters import HTTPAdapter, Retry
 
 from ruamel.yaml import YAML
 
-RELEASES_URL = "https://raw.githubusercontent.com/elastic/logstash/main/ci/logstash_releases.json"
+RELEASES_URL = "https://raw.githubusercontent.com/logstash-plugins/.ci/refs/heads/1.x/logstash-versions.yml"
 TEST_MATRIX_URL = "https://raw.githubusercontent.com/elastic/logstash-filter-elastic_integration/main/.buildkite/pull" \
                   "-request-test-matrix.yml"
 TEST_COMMAND: typing.final = ".buildkite/scripts/run_tests.sh"
@@ -68,7 +68,8 @@ if __name__ == "__main__":
 
     steps = []
     response = call_url_with_retry(RELEASES_URL)
-    versions_json = response.json()
+    yaml = YAML(typ='safe')
+    versions_yaml: typing.final = yaml.load(response.text)
 
     matrix_map = call_url_with_retry(TEST_MATRIX_URL)
     matrix_map_yaml = YAML().load(matrix_map.text)
@@ -88,13 +89,13 @@ if __name__ == "__main__":
     print(f"matrix_releases: {matrix_releases}")
     print(f"matrix_snapshots: {matrix_snapshots}")
     for matrix_release in matrix_releases:
-        full_stack_version: typing.final = versions_json["releases"].get(matrix_release)
+        full_stack_version: typing.final = versions_yaml["releases"].get(matrix_release)
         # noop, if they are declared in the matrix but not in the release
         if full_stack_version is not None:
             steps += generate_unit_and_integration_test_steps(full_stack_version, "false")
 
     for matrix_snapshot in matrix_snapshots:
-        full_stack_version: typing.final = versions_json["snapshots"].get(matrix_snapshot)
+        full_stack_version: typing.final = versions_yaml["snapshots"].get(matrix_snapshot)
         # noop, if they are declared in the matrix but not in the snapshot
         if full_stack_version is not None:
             steps += generate_unit_and_integration_test_steps(full_stack_version, "true")

--- a/.buildkite/scripts/pull-request-pipeline/generate-steps.py
+++ b/.buildkite/scripts/pull-request-pipeline/generate-steps.py
@@ -61,8 +61,10 @@ if __name__ == "__main__":
     structure = {
         "agents": {
             "provider": "gcp",
-            "machineType": "n1-standard-4",
-            "image": "family/core-ubuntu-2204"
+            "machineType": "n2-standard-4",
+            "imageProject": "elastic-images-prod",
+            "image": "family/platform-ingest-logstash-multi-jdk-ubuntu-2204",
+            "diskSizeGb": 120
         },
         "steps": []}
 

--- a/.buildkite/scripts/run_tests.sh
+++ b/.buildkite/scripts/run_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:/opt/buildkite-agent/.java/bin:$PATH"
-export JAVA_HOME="/opt/buildkite-agent/.java"
+export JAVA_HOME="/opt/buildkite-agent/.java/adoptiumjdk_21"
+export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:/opt/buildkite-agent/.java/bin:$JAVA_HOME:$PATH"
 eval "$(rbenv init -)"
 
 if [ -z "$TARGET_BRANCH" ]; then

--- a/.buildkite/scripts/run_tests.sh
+++ b/.buildkite/scripts/run_tests.sh
@@ -6,4 +6,4 @@ else
   git checkout "$TARGET_BRANCH"
 fi
 
-mkdir -p .ci && curl -sL --retry 5 --retry-delay 5 https://github.com/logstash-plugins/.ci/archive/1.x.tar.gz | tar zxvf - --skip-old-files --strip-components=1 -C .ci --wildcards '*Dockerfile*' '*docker*' '*.sh' && .ci/docker-setup.sh && .ci/docker-run.sh
+mkdir -p .ci && curl -sL --retry 5 --retry-delay 5 https://github.com/logstash-plugins/.ci/archive/1.x.tar.gz | tar zxvf - --skip-old-files --strip-components=1 -C .ci --wildcards '*Dockerfile*' '*docker*' '*.sh' '*logstash-versions*' && .ci/docker-setup.sh && .ci/docker-run.sh

--- a/.buildkite/scripts/run_tests.sh
+++ b/.buildkite/scripts/run_tests.sh
@@ -1,3 +1,8 @@
+#!/usr/bin/env bash
+
+export PATH="/opt/buildkite-agent/.rbenv/bin:/opt/buildkite-agent/.pyenv/bin:/opt/buildkite-agent/.java/bin:$PATH"
+export JAVA_HOME="/opt/buildkite-agent/.java"
+eval "$(rbenv init -)"
 
 if [ -z "$TARGET_BRANCH" ]; then
   echo "Target branch is not specified, using default branch: main or BK defined"


### PR DESCRIPTION
This commit updates the buildkite scripts to look in the `.ci` repo in the logstash-plugins org for the new location of logstash releases.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
