### PR TITLE
github-actions: support backport labels after being merged

### DIFF
--- a/.github/workflows/backport-active.yml
+++ b/.github/workflows/backport-active.yml
@@ -2,7 +2,7 @@ name: Backport to active branches
 
 on:
   pull_request_target:
-    types: [closed]
+    types: [closed, labeled]
     branches:
       - main
 
@@ -13,9 +13,13 @@ permissions:
 jobs:
   backport:
     # Only run if the PR was merged (not just closed) and has one of the backport labels
+    # or has been added afterwards.
     if: |
-      github.event.pull_request.merged == true && 
-      contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')
+      github.event.pull_request.merged == true &&
+      (
+        (github.event.action == 'closed' && contains(toJSON(github.event.pull_request.labels.*.name), 'backport-active-')) ||
+        (github.event.action == 'labeled' && startsWith(github.event.label.name, 'backport-active-'))
+      )
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Support backports after a PR has been merged and labelled with `backport-active-*`.

Fixes a corner case when the PRs have been labeled after being merged with the supported list of active branches.