### PR TITLE
Add extra optional packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -491,9 +491,6 @@ task verifyImportedJars() {
     inputs.dir jarsDir
     outputs.dir reportDir
 
-    // Should fail the build (default: true)
-    ext.failOnMissingDeps = project.findProperty('jdeps.failOnMissingDeps') != 'false'
-
     // Logstash provided packages
     ext.providedPackages = [
         'org.apache.logging.log4j',
@@ -654,6 +651,14 @@ task verifyImportedJars() {
 
         def allMissingClasses = missingDeps.values().flatten() as Set
 
+        // class to JARs mapping
+        def classToJars = [:].withDefault { [] as Set }
+        missingDeps.each { jarName, classes ->
+            classes.each { cls ->
+                classToJars[cls] << jarName
+            }
+        }
+
         // Group missing by package
         def missingByPackage = allMissingClasses.groupBy { cls ->
             def parts = cls.split('\\.')
@@ -667,7 +672,9 @@ task verifyImportedJars() {
                 missingByPackage.sort().each { pkg, classes ->
                     w << "${pkg} (${classes.size()} classes):\n"
                     classes.sort().each { cls ->
+                        def jars = classToJars[cls].sort().join(', ')
                         w << "  -> ${cls}\n"
+                        w << "     referenced by: ${jars}\n"
                     }
                     w << "\n"
                 }
@@ -675,7 +682,7 @@ task verifyImportedJars() {
         }
 
         // Fail build if missing deps found
-        if (!missingDeps.isEmpty() && ext.failOnMissingDeps) {
+        if (!missingDeps.isEmpty()) {
             throw new GradleException(
                     "JAR verification failed:\n" +
                     "  - ${allMissingClasses.size()} classes missing from ${missingByPackage.size()} packages\n" +


### PR DESCRIPTION
https://github.com/elastic/logstash-filter-elastic_integration/pull/388 PR shows that dependency validation for 8.19 branch fails because more dependant packages found. But it doesn't seem ingest pipelines require `org.apache.lucene.internal` package and `org.elasticsearch.logging` looks like renamed to `co.elastic.logging` in 9.x.
Specific package list:
```
org.apache.lucene (27 classes, referenced by: lucene-core-9.12.2.jar):
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorer
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorer$CosineScorer
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorer$DotProductScorer
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorer$EuclideanScorer
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorer$MaxInnerProductScorer
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorerSupplier
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorerSupplier$CosineSupplier
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorerSupplier$CosineSupplier$1
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorerSupplier$DotProductSupplier
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorerSupplier$DotProductSupplier$1
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorerSupplier$EuclideanSupplier
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorerSupplier$EuclideanSupplier$1
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorerSupplier$MaxInnerProductSupplier
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentByteVectorScorerSupplier$MaxInnerProductSupplier$1
  -> org.apache.lucene.internal.vectorization.Lucene99MemorySegmentFlatVectorsScorer
  -> org.apache.lucene.internal.vectorization.MemorySegmentPostingDecodingUtil
  -> org.apache.lucene.internal.vectorization.PanamaVectorConstants
  -> org.apache.lucene.internal.vectorization.PanamaVectorUtilSupport
  -> org.apache.lucene.internal.vectorization.PanamaVectorizationProvider
  -> org.apache.lucene.store.MemorySegmentAccessInput
  -> org.apache.lucene.store.MemorySegmentIndexInput
  -> org.apache.lucene.store.MemorySegmentIndexInput$MultiSegmentImpl
  -> org.apache.lucene.store.MemorySegmentIndexInput$SingleSegmentImpl
  -> org.apache.lucene.store.MemorySegmentIndexInputProvider
  -> org.apache.lucene.store.NativeAccess
  -> org.apache.lucene.store.PosixNativeAccess
  -> org.apache.lucene.store.RefCountedSharedArena

org.elasticsearch.logging (4 classes, referenced by: elasticsearch-8.19.12-SNAPSHOT.jar):
  -> org.elasticsearch.logging.Level
  -> org.elasticsearch.logging.LogManager
  -> org.elasticsearch.logging.Logger
  -> org.elasticsearch.logging.internal.spi.LoggerFactory


```