### PR TITLE
Remove 8.previous and 7.x test definitions from E2E pipeline

### DIFF
--- a/.buildkite/scripts/e2e-pipeline/generate-steps.py
+++ b/.buildkite/scripts/e2e-pipeline/generate-steps.py
@@ -38,7 +38,7 @@ def generate_steps_for_scheduler(versions) -> list:
     steps: list = []
     snapshots = versions["snapshots"]
     for snapshot_version in snapshots:
-        if snapshots[snapshot_version] is None or snapshots[snapshot_version].startswith("7.") or snapshot_version == "8.previous":
+        if snapshots[snapshot_version] is None:
             continue
         full_stack_version = snapshots[snapshot_version]
         version_parts = snapshots[snapshot_version].split(".")


### PR DESCRIPTION
The 8.previous and 7.x stack version aliases are being retired. Remove them from the generate-steps skip list.
