### PR TITLE
Upgrade `tools.jackson` dependency.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,11 +56,11 @@ configurations {
     implementation.extendsFrom(logstashCore, elasticsearchMinimalCore, elasticsearchClient)
 }
 
-// TODO: remove this once elasticsearch-java 9.x starts consuming tools.jackson 3.1
+// TODO: remove this once elasticsearch-java 9.x starts consuming tools.jackson 3.1.1+
 configurations.all {
     resolutionStrategy {
-        force 'tools.jackson.core:jackson-core:3.1.0'
-        force 'tools.jackson.core:jackson-databind:3.1.0'
+        force 'tools.jackson.core:jackson-core:3.1.1'
+        force 'tools.jackson.core:jackson-databind:3.1.1'
     }
 }
 


### PR DESCRIPTION
### Description

```
elasticsearchClient
+--- co.elastic.clients:elasticsearch-java:{strictly [9.0, 10.0[} -> 9.4.0
|    +--- io.opentelemetry:opentelemetry-api:1.37.0
|    |    \--- io.opentelemetry:opentelemetry-context:1.37.0
|    +--- io.opentelemetry.semconv:opentelemetry-semconv:1.37.0
|    +--- com.fasterxml.jackson.core:jackson-core:2.21.2
|    |    \--- com.fasterxml.jackson:jackson-bom:2.21.2
|    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.21 (c)
|    |         +--- com.fasterxml.jackson.core:jackson-core:2.21.2 (c)
|    |         \--- com.fasterxml.jackson.core:jackson-databind:2.21.2 (c)
|    +--- com.fasterxml.jackson.core:jackson-databind:2.21.2
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.21
|    |    +--- com.fasterxml.jackson.core:jackson-core:2.21.2 (*)
|    |    \--- com.fasterxml.jackson:jackson-bom:2.21.2 (*)
|    +--- tools.jackson.core:jackson-databind:3.1.0 -> 3.1.1
|    |    +--- com.fasterxml.jackson.core:jackson-annotations:2.21
|    |    +--- tools.jackson.core:jackson-core:3.1.1
|    |    |    \--- tools.jackson:jackson-bom:3.1.1
|    |    |         +--- com.fasterxml.jackson.core:jackson-annotations:2.21 (c)
|    |    |         +--- tools.jackson.core:jackson-core:3.1.1 (c)
|    |    |         \--- tools.jackson.core:jackson-databind:3.1.1 (c)
|    |    \--- tools.jackson:jackson-bom:3.1.1 (*)
|    +--- tools.jackson.core:jackson-core:3.1.0 -> 3.1.1 (*)
|    +--- co.elastic.clients:elasticsearch-rest5-client:9.4.0
|    |    +--- org.eclipse.parsson:parsson:1.1.7
|    |    |    \--- jakarta.json:jakarta.json-api:2.1.3
|    |    +--- org.apache.httpcomponents.client5:httpclient5:5.6.1
|    |    |    +--- org.apache.httpcomponents.core5:httpcore5:5.4
|    |    |    +--- org.apache.httpcomponents.core5:httpcore5-h2:5.4
|    |    |    |    \--- org.apache.httpcomponents.core5:httpcore5:5.4
|    |    |    \--- org.slf4j:slf4j-api:1.7.36
|    |    +--- commons-logging:commons-logging:1.3.5
|    |    \--- jakarta.json:jakarta.json-api:2.1.3
|    +--- com.google.code.findbugs:jsr305:3.0.2
|    +--- jakarta.json:jakarta.json-api:2.1.3
|    +--- org.eclipse.parsson:parsson:1.1.7 (*)
|    \--- commons-logging:commons-logging:1.3.5
\--- org.elasticsearch.client:elasticsearch-rest-client:{strictly [9.0, 10.0[} -> 9.4.0
     +--- org.apache.httpcomponents:httpclient:4.5.14
     |    +--- org.apache.httpcomponents:httpcore:4.4.16
     |    +--- commons-logging:commons-logging:1.2 -> 1.3.5
     |    \--- commons-codec:commons-codec:1.11 -> 1.15
     +--- org.apache.httpcomponents:httpcore:4.4.16
     +--- org.apache.httpcomponents:httpasyncclient:4.1.5
     |    +--- org.apache.httpcomponents:httpcore:4.4.15 -> 4.4.16
     |    +--- org.apache.httpcomponents:httpcore-nio:4.4.15 -> 4.4.16
     |    |    \--- org.apache.httpcomponents:httpcore:4.4.16
     |    +--- org.apache.httpcomponents:httpclient:4.5.13 -> 4.5.14 (*)
     |    \--- commons-logging:commons-logging:1.2 -> 1.3.5
     +--- org.apache.httpcomponents:httpcore-nio:4.4.16 (*)
     +--- commons-codec:commons-codec:1.15
     \--- commons-logging:commons-logging:1.2 -> 1.3.5

```