### PR TITLE
Ship ONLY httpclient5 5.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+  - Include httpclient5/httpcore5 from the `elasticsearch-java` artifact [#455](https://github.com/elastic/logstash-filter-elastic_integration/pull/455)
+
 ## 9.4.1
   - Upgrades `tools.jackson.core` dependency to 3.1.1 [#454](https://github.com/elastic/logstash-filter-elastic_integration/pull/454)
 

--- a/build.gradle
+++ b/build.gradle
@@ -460,7 +460,14 @@ task importMinimalElasticsearch() {
             }
             from(shadeElasticsearchStableBridge.outputs.files.singleFile)
             from(shadeElasticsearchGrokImplementation)
-            from(buildElasticsearchLocalDistro.module("x-pack-core"))
+            from(buildElasticsearchLocalDistro.module("x-pack-core")) {
+                // Exclude httpclient5/httpcore5 jars so the Maven-resolved versions
+                // from elasticsearch-java (via elasticsearchClient config) are used instead.
+                // This ensures we always get the patched version (CVE-2026-40542).
+                exclude jarPackageNamed("httpclient5")
+                exclude jarPackageNamed("httpcore5")
+                exclude jarPackageNamed("httpcore5-h2")
+            }
 
             from(buildElasticsearchLocalDistro.module("ingest-common")) {
                 include jarPackageNamed("ingest-common")
@@ -561,6 +568,10 @@ task verifyImportedJars() {
         // Optional compression/TLS in HTTP clients
         'org.brotli',
         'org.conscrypt',
+
+        // httpclient5/httpcore5 classes are excluded from the x-pack-core module copy
+        // and instead provided by the elasticsearchClient configuration (via elasticsearch-java)
+        'org.apache.hc',
 
         // ES internal packages not used in Logstash context
         'org.elasticsearch.cli',                    // CLI tools


### PR DESCRIPTION
The shadow jar task merges two dependency sources: a `fileTree` copy of jars from the ES source build (`elasticsearchMinimalCore`) and Maven-resolved dependencies from `elasticsearch-java` (`elasticsearchClient`). Because `elasticsearchMinimalCore` is listed first, its `httpclient5-5.5.jar` from x-pack-core takes precedence over the patched `httpclient5-5.6.1.jar` resolved via Maven from `elasticsearch-java 9.4.0`.

Exclude httpclient5, httpcore5, and httpcore5-h2 from the x-pack-core module copy so the Maven-resolved versions are the sole source. This ensures the plugin ships the patched `httpclient5` `5.6.1` regardless of what version the ES server source build bundles.

Related:
- https://github.com/elastic/elasticsearch-java/pull/1227
- https://github.com/elastic/elasticsearch/pull/148345

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
