### PR TITLE
Adds foreign package to the JAR dependencies verification list.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -581,6 +581,7 @@ task verifyImportedJars() {
         // ES internal packages not used in Logstash context
         'org.elasticsearch.cli',                    // CLI tools
         'org.elasticsearch.entitlement',            // Entitlement system
+        'org.elasticsearch.foreign',
         'org.elasticsearch.nativeaccess',           // Native access
         'org.elasticsearch.plugin.analysis',        // Analysis plugins
         'org.elasticsearch.plugin.settings',        // Plugin settings


### PR DESCRIPTION
ES [this PR](https://github.com/elastic/elasticsearch/pull/151164) separated some classes into `foreign` package from `nativeaccess` packages. `elastic_integration` plugin JAR dependency verification process [caught this](https://elastic.slack.com/archives/C0PQDSCGH/p1781896374284069).